### PR TITLE
better handling of suffixed cols

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@ absdist_impl <- function(x, y) {
     .Call('valr_absdist_impl', PACKAGE = 'valr', x, y)
 }
 
-closest_impl <- function(x, y, suffix_x, suffix_y) {
-    .Call('valr_closest_impl', PACKAGE = 'valr', x, y, suffix_x, suffix_y)
+closest_impl <- function(x, y, suffix_y) {
+    .Call('valr_closest_impl', PACKAGE = 'valr', x, y, suffix_y)
 }
 
 complement_impl <- function(gdf, genome) {
@@ -17,8 +17,8 @@ coverage_impl <- function(x, y) {
     .Call('valr_coverage_impl', PACKAGE = 'valr', x, y)
 }
 
-intersect_impl <- function(x, y, suffix_x = ".x", suffix_y = ".y") {
-    .Call('valr_intersect_impl', PACKAGE = 'valr', x, y, suffix_x, suffix_y)
+intersect_impl <- function(x, y, suffix_y = ".y") {
+    .Call('valr_intersect_impl', PACKAGE = 'valr', x, y, suffix_y)
 }
 
 merge_impl <- function(gdf, max_dist = 0L) {

--- a/R/bed_closest.r
+++ b/R/bed_closest.r
@@ -3,7 +3,7 @@
 #' @param x tbl of intervals
 #' @param y tbl of intervals
 #' @param overlap report overlapping intervals 
-#' @param suffix colname suffixes in output
+#' @param suffix colname suffix for \code{y} columns in output
 #' @param dist format for distance to nearest interval
 #'              
 #' @template groups

--- a/R/bed_closest.r
+++ b/R/bed_closest.r
@@ -57,7 +57,7 @@
 #' 
 #' @export
 bed_closest <- function(x, y, overlap = TRUE,
-                        suffix = c('.x', '.y'),
+                        suffix = c('.y'),
                         dist = c("genome", "strand", "abs")) {
   
   check_suffix(suffix) 
@@ -68,16 +68,16 @@ bed_closest <- function(x, y, overlap = TRUE,
   y <- arrange(y, chrom, start)
   y <- group_by(y, chrom, add = TRUE)
  
-  suffix <- list(x = suffix[1], y = suffix[2])
+  suffix <- list(y = suffix[1])
   
-  res <- closest_impl(x, y, suffix$x, suffix$y)
+  res <- closest_impl(x, y, suffix$y)
 
   dist <- match.arg(dist, c("genome", "strand", "abs"))
   
   # modify distance output based on user input 
   # genome type reporting is default output from closest_impl())
   if (dist == "strand") {
-    res$.dist <- ifelse(res$strand.x == "+", res$.dist, -(res$.dist))
+    res$.dist <- ifelse(res$strand == "+", res$.dist, -(res$.dist))
   } else if (dist == "abs") {
     res$.dist <- abs(res$.dist)
   } 

--- a/R/bed_intersect.r
+++ b/R/bed_intersect.r
@@ -57,19 +57,19 @@
 #' 
 #' 
 #' @export
-bed_intersect <- function(x, y, invert = FALSE, suffix = c('.x', '.y'), ...) {
+bed_intersect <- function(x, y, invert = FALSE, suffix = c('.y'), ...) {
  
   check_suffix(suffix) 
  
   x <- group_by(x, chrom, add = TRUE)
   y <- group_by(y, chrom, add = TRUE)
 
-  suffix <- list(x = suffix[1], y = suffix[2])
+  suffix <- list(y = suffix[1])
 
-  res <- intersect_impl(x, y, suffix$x, suffix$y)
+  res <- intersect_impl(x, y, suffix$y)
   
   if (invert) {
-    colspec <- c('chrom' = 'chrom', 'start' = 'start.x', 'end' = 'end.x') 
+    colspec <- c('chrom', 'start', 'end') 
     res <- anti_join(x, res, by = colspec)
     res <- ungroup(res)
   }

--- a/R/bed_intersect.r
+++ b/R/bed_intersect.r
@@ -7,7 +7,7 @@
 #' @param x tbl of intervals
 #' @param y tbl of intervals
 #' @param invert report \code{x} intervals not in \code{y}
-#' @param suffix colname suffixes in output
+#' @param suffix colname suffix for \code{y} columns in output
 #' @param ... extra arguments (not used)
 #'   
 #' @return a \code{data_frame} with original columns from \code{x} and \code{y},

--- a/R/bed_map.r
+++ b/R/bed_map.r
@@ -69,12 +69,15 @@
 #' 
 #' @export
 bed_map <- function(x, y, ..., invert = FALSE,
+                    suffix = c(".y"),
                     min_overlap = 1) {
   
   groups_x <- groups(x)
   
-  # used only to get the `x` suffix; `y` suffix is ignored` 
-  suffix <- list(y = ".y")
+  check_suffix(suffix)
+  
+  # used only internally to distinguish x and y columns 
+  suffix <- list(y = suffix[1])
  
   x_names <- colnames(x)[!colnames(x) %in% "chrom"]
  
@@ -88,7 +91,7 @@ bed_map <- function(x, y, ..., invert = FALSE,
   x_names_suffix <- stringr::str_c(x_names, ".x")
   
   ## remove y suffix, but don't pattern match with '.' regex
-  names_no_y <- stringr::str_replace(names(res), stringr::fixed(".y"), '')
+  names_no_y <- stringr::str_replace(names(res), stringr::fixed(suffix$y), '')
   names(res) <- names_no_y
   
   res <- filter(res, .overlap >= min_overlap)
@@ -98,7 +101,7 @@ bed_map <- function(x, y, ..., invert = FALSE,
   res <- summarize_(res, .dots = lazyeval::lazy_dots(...))
   res <- ungroup(res)
   ## remove x suffix, but don't pattern match with '.' regex
-  names_no_x <- stringr::str_replace(names(res), stringr::fixed(".x"), '')
+  names_no_x <- stringr::str_replace(names(res), "[.]x$", '')
   names(res) <- names_no_x
   
   # find rows of `x` that did not intersect

--- a/R/bed_projection.r
+++ b/R/bed_projection.r
@@ -4,6 +4,7 @@
 #' @param y tbl of intervals
 #' @param genome chrom sizes
 #' @param by_chrom compute test per chromosome
+#' @param ... additional arguments passed on to \code{bed_intersect()}
 #' 
 #' @template stats
 #' 
@@ -55,7 +56,7 @@
 #' bed_projection(x, y, genome, by_chrom = TRUE)
 #' 
 #' @export
-bed_projection <- function(x, y, genome, by_chrom = FALSE) {
+bed_projection <- function(x, y, genome, by_chrom = FALSE, ...) {
 
   #find midpoints
   x <- mutate(x, .midpoint = round((end + start) / 2),
@@ -67,7 +68,7 @@ bed_projection <- function(x, y, genome, by_chrom = FALSE) {
   y <- bed_merge(y)
   
   # count overlaps per chromosome, 
-  obs_counts <- bed_intersect(x, y)
+  obs_counts <- bed_intersect(x, y, ...)
 
   # count overlaps
   obs_counts <- group_by(obs_counts, chrom)

--- a/R/bed_subtract.r
+++ b/R/bed_subtract.r
@@ -57,7 +57,7 @@ bed_subtract <- function(x, y, any = FALSE) {
   if (any) {
     # collect and return x intervals without overlaps 
     res <- bed_intersect(x, y)
-    colspec <- c('chrom', 'start' = 'start.x', 'end' = 'end.x')
+    colspec <- c('chrom', 'start', 'end')
     anti <- anti_join(x, res, by = colspec)
    
     return(anti)

--- a/R/bed_window.r
+++ b/R/bed_window.r
@@ -48,6 +48,7 @@
 #' )
 #' 
 #' bed_window(x, y, genome, both = 100)
+#' bed_window(x, y, genome, both = 100, trim  = TRUE)
 #' 
 #' @seealso \url{http://bedtools.readthedocs.org/en/latest/content/tools/window.html}
 #'  
@@ -60,11 +61,11 @@ bed_window <- function(x, y, genome, ...) {
   
   res <- bed_intersect(slop_x, y, ...)
   
-  res <- mutate(res, start.x = .start.x, end.x = .end.x)
+  res <- mutate(res, start = .start, end = .end)
   
   res <- ungroup(res)
   
-  res <- select(res, -.start.x, -.end.x)
+  res <- select(res, -.start, -.end)
   
   res
 }

--- a/R/globals.r
+++ b/R/globals.r
@@ -14,4 +14,4 @@ globalVariables(c("chrom", "start", "end", "strand",
                   "right_start", ".total", "value",
                   ".midpoint", ".obs_counts", ".length",
                   ".reference_coverage", ".total_trials", ".exp_prob",
-                  "p.value"))
+                  "p.value", ".row_id", ".win_size"))

--- a/R/utils.r
+++ b/R/utils.r
@@ -94,6 +94,6 @@ shared_groups <- function(x, y) {
 
 # dplyr::check_suffix
 check_suffix <- function(suffix) {
-  if (!is.character(suffix) || length(suffix) != 2)
-    stop("`suffix` must be a character vector of length 2.", call. = FALSE)
+  if (!is.character(suffix) || length(suffix) != 1)
+    stop("`suffix` must be a character of length 1.", call. = FALSE)
 }

--- a/man/bed_closest.Rd
+++ b/man/bed_closest.Rd
@@ -4,8 +4,8 @@
 \alias{bed_closest}
 \title{Identify closest intervals.}
 \usage{
-bed_closest(x, y, overlap = TRUE, suffix = c(".x", ".y"),
-  dist = c("genome", "strand", "abs"))
+bed_closest(x, y, overlap = TRUE, suffix = c(".y"), dist = c("genome",
+  "strand", "abs"))
 }
 \arguments{
 \item{x}{tbl of intervals}
@@ -14,7 +14,7 @@ bed_closest(x, y, overlap = TRUE, suffix = c(".x", ".y"),
 
 \item{overlap}{report overlapping intervals}
 
-\item{suffix}{colname suffixes in output}
+\item{suffix}{colname suffix for \code{y} columns in output}
 
 \item{dist}{format for distance to nearest interval}
 }

--- a/man/bed_intersect.Rd
+++ b/man/bed_intersect.Rd
@@ -4,7 +4,7 @@
 \alias{bed_intersect}
 \title{Identify intersecting intervals.}
 \usage{
-bed_intersect(x, y, invert = FALSE, suffix = c(".x", ".y"), ...)
+bed_intersect(x, y, invert = FALSE, suffix = c(".y"), ...)
 }
 \arguments{
 \item{x}{tbl of intervals}
@@ -13,7 +13,7 @@ bed_intersect(x, y, invert = FALSE, suffix = c(".x", ".y"), ...)
 
 \item{invert}{report \code{x} intervals not in \code{y}}
 
-\item{suffix}{colname suffixes in output}
+\item{suffix}{colname suffix for \code{y} columns in output}
 
 \item{...}{extra arguments (not used)}
 }

--- a/man/bed_map.Rd
+++ b/man/bed_map.Rd
@@ -7,8 +7,7 @@
 \alias{values_unique}
 \title{Calculate summaries and statistics from overlapping intervals.}
 \usage{
-bed_map(x, y, ..., invert = FALSE, suffix = c(".x", ".y"),
-  min_overlap = 1)
+bed_map(x, y, ..., invert = FALSE, suffix = c(".y"), min_overlap = 1)
 
 concat(.data, sep = ",")
 
@@ -25,7 +24,7 @@ values(.data, sep = ",")
 
 \item{invert}{report \code{x} intervals not in \code{y}}
 
-\item{suffix}{colname suffixes in output}
+\item{suffix}{colname suffix for \code{y} columns in output}
 
 \item{min_overlap}{minimum overlap for intervals.}
 

--- a/man/bed_projection.Rd
+++ b/man/bed_projection.Rd
@@ -4,7 +4,7 @@
 \alias{bed_projection}
 \title{Projection test for query interval overlap.}
 \usage{
-bed_projection(x, y, genome, by_chrom = FALSE)
+bed_projection(x, y, genome, by_chrom = FALSE, ...)
 }
 \arguments{
 \item{x}{tbl of intervals}
@@ -14,6 +14,8 @@ bed_projection(x, y, genome, by_chrom = FALSE)
 \item{genome}{chrom sizes}
 
 \item{by_chrom}{compute test per chromosome}
+
+\item{...}{additional arguments passed on to \code{bed_intersect()}}
 }
 \value{
 \code{data_frame} with the following columns:

--- a/man/bed_window.Rd
+++ b/man/bed_window.Rd
@@ -66,6 +66,7 @@ genome <- tibble::tribble(
 )
 
 bed_window(x, y, genome, both = 100)
+bed_window(x, y, genome, both = 100, trim  = TRUE)
 
 }
 \seealso{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -20,16 +20,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // closest_impl
-DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y, const std::string& suffix_x, const std::string& suffix_y);
-RcppExport SEXP valr_closest_impl(SEXP xSEXP, SEXP ySEXP, SEXP suffix_xSEXP, SEXP suffix_ySEXP) {
+DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y, const std::string& suffix_y);
+RcppExport SEXP valr_closest_impl(SEXP xSEXP, SEXP ySEXP, SEXP suffix_ySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< GroupedDataFrame >::type x(xSEXP);
     Rcpp::traits::input_parameter< GroupedDataFrame >::type y(ySEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type suffix_x(suffix_xSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type suffix_y(suffix_ySEXP);
-    rcpp_result_gen = Rcpp::wrap(closest_impl(x, y, suffix_x, suffix_y));
+    rcpp_result_gen = Rcpp::wrap(closest_impl(x, y, suffix_y));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -58,16 +57,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // intersect_impl
-DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y, const std::string& suffix_x, const std::string& suffix_y);
-RcppExport SEXP valr_intersect_impl(SEXP xSEXP, SEXP ySEXP, SEXP suffix_xSEXP, SEXP suffix_ySEXP) {
+DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y, const std::string& suffix_y);
+RcppExport SEXP valr_intersect_impl(SEXP xSEXP, SEXP ySEXP, SEXP suffix_ySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< GroupedDataFrame >::type x(xSEXP);
     Rcpp::traits::input_parameter< GroupedDataFrame >::type y(ySEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type suffix_x(suffix_xSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type suffix_y(suffix_ySEXP);
-    rcpp_result_gen = Rcpp::wrap(intersect_impl(x, y, suffix_x, suffix_y));
+    rcpp_result_gen = Rcpp::wrap(intersect_impl(x, y, suffix_y));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/closest.cpp
+++ b/src/closest.cpp
@@ -48,16 +48,10 @@ void closest_grouped(intervalVector& vx, intervalVector& vy,
 
 //[[Rcpp::export]]
 DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y,
-                       const std::string& suffix_x, const std::string& suffix_y) {
-
-//  auto ng_x = x.ngroups() ;
-//  auto ng_y = y.ngroups() ;
+                       const std::string& suffix_y) {
 
   DataFrame df_x = x.data() ;
   DataFrame df_y = y.data() ;
-
-//  auto nr_x = df_x.nrows() ;
-//  auto nr_y = df_y.nrows() ;
 
   // for subsetting / return df
   std::vector<int> indices_x ;
@@ -85,9 +79,6 @@ DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y,
   // x names, data
   for (int i=0; i<ncol_x; i++) {
     auto name_x = as<std::string>(names_x[i]) ;
-    if (name_x != "chrom") {
-      name_x += suffix_x ;
-    }
     names[i] = name_x ;
     out[i] = subset_x[i] ;
   }

--- a/src/intersect.cpp
+++ b/src/intersect.cpp
@@ -27,7 +27,6 @@ void intersect_group(intervalVector vx, intervalVector vy,
 
 //[[Rcpp::export]]
 DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y,
-                         const std::string& suffix_x = ".x",
                          const std::string& suffix_y = ".y") {
 
   // indices for subsetting
@@ -58,9 +57,6 @@ DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y,
   // x names, data
   for (int i=0; i<ncol_x; i++) {
     auto name_x = as<std::string>(names_x[i]) ;
-    if (name_x != "chrom") {
-      name_x += suffix_x ;
-    }
     names[i] = name_x ;
     out[i] = subset_x[i] ;
   }

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -122,7 +122,7 @@ test_that("check that same strand is reported (strand = TRUE", {
   ) 
   
   pred <- tibble::tribble(
-    ~chrom,   ~start.x,    ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y,    ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    ~chrom,   ~start,    ~end, ~name, ~score, ~strand, ~start.y,    ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
     "chr1",	 80,	100,	"q1",	1,	"+",	5, 	15, 	"d1.1",	1,	"+", 0, -65 
   )
   
@@ -145,7 +145,7 @@ test_that("check that different strand is reported (strand_opp = TRUE", {
   ) 
   
   pred <- tibble::tribble(
-    ~chrom,   ~start.x,    ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom,   ~start,    ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",	 80,	100,	"q1",	1,	"+",	20, 	60, 	"d1.2",	2,	"+", 0, -20 
   )
   
@@ -250,7 +250,7 @@ test_that("all overlapping features are reported", {
     "chr1", 200,   300
   )
   exp <- tibble::tribble(
-    ~chrom, ~start.x, ~start.y,
+    ~chrom, ~start, ~start.y,
     "chr1", 100,    200
   )
   res <- bed_closest(x, y)
@@ -278,7 +278,7 @@ test_that("test reporting of first overlapping feature and
     "chr1",	175,	375
 )
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~start.y, ~end.y, ~.dist,
+    ~chrom, ~start, ~end, ~start.y, ~end.y, ~.dist,
     "chr1",	100,	101,  150,  201,  49,
     "chr1",	200,	201,  100,  101, -99,
     "chr1",	300,	301,  150,  201, -99,
@@ -325,7 +325,7 @@ d_d2R <- tibble::tribble(
 
 test_that("default distance reporting works for forward hit on left, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1F.1",      10,        "+",        0,       -20
   ) 
   res <- bed_closest(d_q1, d_d1F)
@@ -335,7 +335,7 @@ test_that("default distance reporting works for forward hit on left, forward que
 
 test_that("strand distance reporting works for forward hit on left, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1F.1",      10,        "+",        0,       -20
   ) 
   res <- bed_closest(d_q1, d_d1F, dist = "strand")
@@ -345,7 +345,7 @@ test_that("strand distance reporting works for forward hit on left, forward quer
 
 test_that("abs distance reporting works for forward hit on left, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1F.1",      10,        "+",        0,       20
   ) 
   res <- bed_closest(d_q1, d_d1F, dist = "abs")
@@ -355,7 +355,7 @@ test_that("abs distance reporting works for forward hit on left, forward query",
 
 test_that("default distance reporting works for reverse hit on left, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1R.1",      10,        "-",        0,       -20
   ) 
   res <- bed_closest(d_q1, d_d1R)
@@ -365,7 +365,7 @@ test_that("default distance reporting works for reverse hit on left, forward que
 
 test_that("strand distance reporting works for reverse hit on left, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1R.1",      10,        "-",        0,       -20
   ) 
   res <- bed_closest(d_q1, d_d1R, dist = "strand")
@@ -375,7 +375,7 @@ test_that("strand distance reporting works for reverse hit on left, forward quer
 
 test_that("default distance reporting works for forward hit on left, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1F.1",      10,        "+",        0,       -20
   ) 
   res <- bed_closest(d_q2, d_d1F)
@@ -385,7 +385,7 @@ test_that("default distance reporting works for forward hit on left, reverse que
 
 test_that("strand distance reporting works for forward hit on left, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1F.1",      10,        "+",        0,       20
   ) 
   res <- bed_closest(d_q2, d_d1F, dist = "strand")
@@ -395,7 +395,7 @@ test_that("strand distance reporting works for forward hit on left, reverse quer
 
 test_that("abs distance reporting works for forward hit on left, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1F.1",      10,        "+",        0,       20
   ) 
   res <- bed_closest(d_q2, d_d1F, dist = "abs")
@@ -405,7 +405,7 @@ test_that("abs distance reporting works for forward hit on left, reverse query",
 
 test_that("default distance reporting works for reverse hit on left, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1R.1",      10,        "-",        0,       -20
   ) 
   res <- bed_closest(d_q2, d_d1R)
@@ -415,7 +415,7 @@ test_that("default distance reporting works for reverse hit on left, reverse que
 
 test_that("strand distance reporting works for reverse hit on left, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1R.1",      10,        "-",        0,       20
   ) 
   res <- bed_closest(d_q2, d_d1R, dist = "strand")
@@ -425,7 +425,7 @@ test_that("strand distance reporting works for reverse hit on left, reverse quer
 
 test_that("abs distance reporting works for reverse hit on left, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1R.1",      10,        "-",        0,       20
   ) 
   res <- bed_closest(d_q2, d_d1R, dist = "abs")
@@ -436,7 +436,7 @@ test_that("abs distance reporting works for reverse hit on left, reverse query",
 
 test_that("default distance reporting works for forward hit on right, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2F.1",      10,        "+",        0,      40 
   ) 
   res <- bed_closest(d_q1, d_d2F)
@@ -446,7 +446,7 @@ test_that("default distance reporting works for forward hit on right, forward qu
 
 test_that("strand distance reporting works for forward hit on right, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2F.1",      10,        "+",        0,       40
   ) 
   res <- bed_closest(d_q1, d_d2F, dist = "strand")
@@ -456,7 +456,7 @@ test_that("strand distance reporting works for forward hit on right, forward que
 
 test_that("abs distance reporting works for forward hit on right, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2F.1",      10,        "+",        0,       40
   ) 
   res <- bed_closest(d_q1, d_d2F, dist = "abs")
@@ -466,7 +466,7 @@ test_that("abs distance reporting works for forward hit on right, forward query"
 
 test_that("default distance reporting works for reverse hit on right, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2R.1",      10,        "-",        0,      40 
   ) 
   res <- bed_closest(d_q1, d_d2R)
@@ -476,7 +476,7 @@ test_that("default distance reporting works for reverse hit on right, forward qu
 
 test_that("strand distance reporting works for rverse hit on right, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2R.1",      10,        "-",        0,       40
   ) 
   res <- bed_closest(d_q1, d_d2R, dist = "strand")
@@ -486,7 +486,7 @@ test_that("strand distance reporting works for rverse hit on right, forward quer
 
 test_that("abs distance reporting works for reverse hit on right, forward query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2R.1",      10,        "-",        0,       40
   ) 
   res <- bed_closest(d_q1, d_d2R, dist = "abs")
@@ -496,7 +496,7 @@ test_that("abs distance reporting works for reverse hit on right, forward query"
 
 test_that("default distance reporting works for forward hit on right, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2F.1",      10,        "+",        0,      40 
   ) 
   res <- bed_closest(d_q2, d_d2F)
@@ -506,7 +506,7 @@ test_that("default distance reporting works for forward hit on right, reverse qu
 
 test_that("strand distance reporting works for forward hit on right, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2F.1",      10,        "+",        0,       -40
   ) 
   res <- bed_closest(d_q2, d_d2F, dist = "strand")
@@ -516,7 +516,7 @@ test_that("strand distance reporting works for forward hit on right, reverse que
 
 test_that("abs distance reporting works for forward hit on right, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2F.1",      10,        "+",        0,       40
   ) 
   res <- bed_closest(d_q2, d_d2F, dist = "abs")
@@ -526,7 +526,7 @@ test_that("abs distance reporting works for forward hit on right, reverse query"
 
 test_that("default distance reporting works for reverse hit on right, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2R.1",      10,        "-",        0,      40 
   ) 
   res <- bed_closest(d_q2, d_d2R)
@@ -536,7 +536,7 @@ test_that("default distance reporting works for reverse hit on right, reverse qu
 
 test_that("strand distance reporting works for reverse hit on right, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2R.1",      10,        "-",        0,       -40
   ) 
   res <- bed_closest(d_q2, d_d2R, dist = "strand")
@@ -546,7 +546,7 @@ test_that("strand distance reporting works for reverse hit on right, reverse que
 
 test_that("abs distance reporting works for reverse hit on right, reverse query", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2R.1",      10,        "-",        0,       40
   ) 
   res <- bed_closest(d_q2, d_d2R, dist = "abs")
@@ -568,7 +568,7 @@ b2 <- tibble::tribble(
 
 test_that("Make sure non-overlapping ties are reported ", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      10,   20, "a1",       1,        "-",      8,    9,  "b1",      1,        "+",        0,       -1,
     "chr1",      10,   20, "a1",       1,        "-",      21,    22,  "b2",      1,        "-",        0,       1
   ) 
@@ -579,7 +579,7 @@ test_that("Make sure non-overlapping ties are reported ", {
 
 test_that("Make sure non-overlapping ties are reported with strand = T ", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      10,   20, "a1",       1,        "-",      21,    22,  "b2",      1,        "-",        0,       1
   ) 
   res <- bed_closest(group_by(a2, strand), group_by(b2, strand))
@@ -590,7 +590,7 @@ test_that("Make sure non-overlapping ties are reported with strand = T ", {
 
 test_that("Make sure non-overlapping ties are reported with strand_opp = T ", {
   pred <- tibble::tribble(
-    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
+    ~chrom, ~start, ~end, ~name, ~score, ~strand, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
     "chr1",      10,   20, "a1",       1,        "-",      8,    9,  "b1",      1,        "-",        0,       -1
   ) 
   res <- bed_closest(group_by(a2, strand), group_by(flip_strands(b2), strand))
@@ -622,7 +622,7 @@ test_that("test that a max of two duplicated x ivls are returned, assuming non-o
   genes <- group_by(genes, chrom)
   
   res <- bed_closest(snps, genes, overlap = FALSE)
-  res <- group_by(res, chrom, start.x, end.x) 
+  res <- group_by(res, chrom, start, end) 
   res <- summarize(res, n = n())
   # there should not be more than 2 possible closest ivls. 
   expect_true(all(res$n <= 2))
@@ -649,7 +649,7 @@ test_that("ensure that subtraction is done with respect to input tbls issue#108"
   x_grouped <- arrange(x, chrom, start) %>% group_by(group, chrom)
   y_grouped <- arrange(y, chrom, start) %>% group_by(group, chrom)
   res <- bed_closest(x_grouped, y_grouped)
-  expect_true(all(res$group.x == res$group.y))
+  expect_true(all(res$group == res$group.y))
 })
 
 

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -652,7 +652,53 @@ test_that("ensure that subtraction is done with respect to input tbls issue#108"
   expect_true(all(res$group == res$group.y))
 })
 
+test_that("ensure that output can be piped to other valr functions #161", {
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end, ~group,
+    'chr1', 100,    200,  'A',
+    'chr1', 200,    400,  'A',
+    'chr1', 300,    500,  'A',
+    'chr1', 125,    175,  'C',
+    'chr1', 150,    200,  'B'
+  )
+  y <- tibble::tribble(
+    ~chrom, ~start, ~end, ~group,
+    'chr1', 100,    200,  'A',
+    'chr1', 200,    400,  'B',
+    'chr1', 300,    500,  'A',
+    'chr1', 125,    175,  'C',
+    'chr2', 150,    200,  'A'
+  )
+  
+  genome <- tibble::tribble(
+    ~chrom, ~size,
+    'chr1', 1000,
+    'chr2', 2000
+  )
+  
+  res <- bed_closest(x, y)
 
+  expect_is(res %>% bed_cluster(.), "tbl_df")
+  expect_is(res %>% bed_complement(., genome), "tbl_df")
+  expect_is(res %>% bed_flank(., both = 100, genome), "tbl_df")
+  expect_is(res %>% bed_makewindows(., genome, 100), "tbl_df")
+  expect_is(res %>% bed_flank(., genome, 10), "tbl_df")
+  expect_is(res %>% 
+              rename(.x_overlap = .overlap) %>% 
+              bed_map(., y, suffix = ".test"), "tbl_df")
+  expect_is(res %>% bed_merge(.), "tbl_df")
+  expect_is(res %>% 
+              rename(.x_overlap = .overlap) %>% 
+              bed_projection(., y, suffix = ".test", genome), "tbl_df")
+  expect_is(res %>% bed_reldist(., y), "tbl_df")
+  expect_is(res %>% bed_shift(., genome, 100), "tbl_df")
+  expect_is(res %>% bed_shuffle(., genome), "tbl_df")
+  expect_is(res %>% bed_slop(., genome, both = 100), "tbl_df")
+  expect_is(res %>% bed_subtract(., y), "tbl_df")
+  expect_is(res %>% 
+              rename(.x_overlap = .overlap) %>% 
+              bed_window(., y, suffix = ".test", genome), "tbl_df")
+})
 
 
 

--- a/tests/testthat/test_intersect.r
+++ b/tests/testthat/test_intersect.r
@@ -185,3 +185,52 @@ test_that("tbls grouped by strand are processed", {
   res <- bed_intersect(group_by(x, strand), group_by(flip_strands(y), strand))
   expect_equal(nrow(res), 1)
 })
+
+test_that("ensure that output can be piped to other valr functions #161", {
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end, ~group,
+    'chr1', 100,    200,  'A',
+    'chr1', 200,    400,  'A',
+    'chr1', 300,    500,  'A',
+    'chr1', 125,    175,  'C',
+    'chr1', 150,    200,  'B'
+  )
+  y <- tibble::tribble(
+    ~chrom, ~start, ~end, ~group,
+    'chr1', 100,    200,  'A',
+    'chr1', 200,    400,  'B',
+    'chr1', 300,    500,  'A',
+    'chr1', 125,    175,  'C',
+    'chr2', 150,    200,  'A'
+  )
+  
+  genome <- tibble::tribble(
+    ~chrom, ~size,
+    'chr1', 1000,
+    'chr2', 2000
+  )
+  
+  res <- bed_intersect(x, y)
+  
+  expect_is(res %>% bed_cluster(.), "tbl_df")
+  expect_is(res %>% bed_complement(., genome), "tbl_df")
+  expect_is(res %>% bed_flank(., both = 100, genome), "tbl_df")
+  expect_is(res %>% bed_makewindows(., genome, 100), "tbl_df")
+  expect_is(res %>% bed_flank(., genome, 10), "tbl_df")
+  expect_is(res %>% 
+              rename(.x_overlap = .overlap) %>% 
+              bed_map(., y, suffix = ".test"), "tbl_df")
+  expect_is(res %>% bed_merge(.), "tbl_df")
+  expect_is(res %>% 
+              rename(.x_overlap = .overlap) %>% 
+              bed_projection(., y, suffix = ".test", genome), "tbl_df")
+  expect_is(res %>% bed_reldist(., y), "tbl_df")
+  expect_is(res %>% bed_shift(., genome, 100), "tbl_df")
+  expect_is(res %>% bed_shuffle(., genome), "tbl_df")
+  expect_is(res %>% bed_slop(., genome, both = 100), "tbl_df")
+  expect_is(res %>% bed_subtract(., y), "tbl_df")
+  expect_is(res %>% 
+              rename(.x_overlap = .overlap) %>% 
+              bed_window(., y, suffix = ".test", genome), "tbl_df")
+})
+

--- a/tests/testthat/test_intersect.r
+++ b/tests/testthat/test_intersect.r
@@ -112,13 +112,13 @@ test_that("incorrect `suffix` args throw errors", {
     ~chrom, ~start, ~end, ~name, ~score,
     "chr1", 1000,   1500, '.',   '.'
   )
-  
+ 
   y <- tibble::tribble(
-    ~chrom, ~start, ~end, ~name, ~score,
+   ~chrom, ~start, ~end, ~name, ~score,
     "chr1", 1000,   1200, '.',   '.'
   )
   
-  expect_error(bed_intersect(x, y, suffix = 'TESTING')) 
+  expect_error(bed_intersect(x, y, suffix = c(1, "2"))) 
 })
 
 test_that("intersections from x bed_tbl with more chroms than y are captured", {
@@ -163,7 +163,7 @@ test_that("input x groups are used for comparing intervals issue #108",{
   x <- arrange(x, chrom, start)
   x <- group_by(x, group)
   res <- bed_intersect(x, x)
-  expect_true(all(res$group.x == res$group.y))
+  expect_true(all(res$group == res$group.y))
   
 })
 


### PR DESCRIPTION
This PR introduces changes to the way suffixes are handled in `valr` functions. Previously, columns from input `x` and `y` tbls would be suffixed in the output, which would lead to incompatibility with other `valr` functions that expected non-suffixed colnames (e.g. `start`, `end`, `strand`). 

The proposed changes return suffixed columns for the `y` tbl columns only. `bed_map()` internally has an exception to this behavior, so that the user can define functions to operate on intersected `y` tbl cols.

Additionally:
  1) Some tests needed to be changed to remove references to `x` suffixes. 
  2) The `check_suffix()` function was altered to check for suffixes of length 1 (See [here](https://github.com/rnabioco/valr/compare/master...kriemo:col_suffix_issue%23161?diff=split&expand=1&name=col_suffix_issue%23161#diff-475284c83f91b5f64ec0e4afdbd4c955L97))
  3) There were two global variables introduced in #160 that needed to be added to the [globals](https://github.com/rnabioco/valr/compare/master...kriemo:col_suffix_issue%23161?diff=split&expand=1&name=col_suffix_issue%23161#diff-5335d06aecdeee6512e9149010a9c5b1L14)
  4) I've added integration style tests for `bed_closest()` and `bed_intersect()` that test for pipe compatibility with other `valr` functions.  However, note that there are a few edge cases where piping will not work without column renaming for `bed_map()`, `bed_projection()`, and `bed_window()`.  (See below)

(Using code changes from this PR)
```r 
  x <- tibble::tribble(
    ~chrom, ~start, ~end, ~group,
    'chr1', 100,    200,  'A',
    'chr1', 200,    400,  'A',
    'chr1', 300,    500,  'A',
    'chr1', 125,    175,  'C',
    'chr1', 150,    200,  'B'
  )
  y <- tibble::tribble(
    ~chrom, ~start, ~end, ~group,
    'chr1', 100,    200,  'A',
    'chr1', 200,    400,  'B',
    'chr1', 300,    500,  'A',
    'chr1', 125,    175,  'C',
    'chr2', 150,    200,  'A'
  )
  
  genome <- tibble::tribble(
    ~chrom, ~size,
    'chr1', 1000,
    'chr2', 2000
  )
  
  bed_intersect(x, y) %>% 
    bed_projection(., y, genome)
#> Error: found duplicated column name: start.y, end.y, .overlap
    
  bed_intersect(x, y) %>% 
    bed_projection(., y, genome, suffix = ".z")
#> Error: found duplicated column name: .overlap
    
  bed_intersect(x, y) %>% 
    rename(.overlap.y = .overlap) %>% 
    bed_projection(., y, genome, suffix = ".z")
#> # A tibble: 1 × 4
#>          chrom p.value obs_exp_ratio lower_tail
#>          <chr>   <dbl>         <dbl>      <chr>
#> 1 whole_genome       0           2.5      FALSE
```