### PR TITLE
track ids independent of groups in bed_cluster

### DIFF
--- a/R/bed_cluster.r
+++ b/R/bed_cluster.r
@@ -1,20 +1,20 @@
 #' Cluster neighboring intervals.
-#' 
+#'
 #' Output contains an \code{.id} column that can be used in downstream grouping
 #' operations. Default \code{max_dist = 0} means that both overlapping and
 #' book-ended intervals will be clustered.
-#' 
-#' @param x tbl of intervals
+#'
+#' @param x tbl of interval
 #' @param max_dist maximum distance between clustered intervals.
-#'   
+#'
 #' @template groups
-#'   
+#'
 #' @return \code{data_frame} with \code{.id} column for clustered intervals.
-#'   
+#'
 #' @family single-set-ops
-#' @seealso 
+#' @seealso
 #' \url{http://bedtools.readthedocs.org/en/latest/content/tools/cluster.html}
-#' 
+#'
 #' @examples
 #' x <- tibble::tribble(
 #'  ~chrom, ~start, ~end,
@@ -23,9 +23,9 @@
 #'  "chr1", 250,  500,
 #'  "chr1", 501,  1000
 #' )
-#' 
+#'
 #' bed_cluster(x)
-#' 
+#'
 #' # glyph illustrating clustering of overlapping and book-ended intervals
 #' x <- tibble::tribble(
 #'   ~chrom, ~start, ~end,
@@ -35,20 +35,20 @@
 #'   'chr1', 40,     50,
 #'   'chr1', 80,     90
 #' )
-#' 
+#'
 #' bed_glyph(bed_cluster(x), label = '.id')
-#' 
+#'
 #' @export
 bed_cluster <- function(x, max_dist = 0) {
 
   res <- group_by(x, chrom, add = TRUE)
-  
+  res <- arrange(res, chrom, start)
+
   res <- merge_impl(res, max_dist)
-    
-  res <- group_by(res, chrom)
-  res <- mutate(res, .id = dense_rank(.id_merge))
+
+  res <- mutate(res, .id = .id_merge)
   res <- select(res, -.id_merge, -.overlap_merge)
   res <- ungroup(res)
-  
+
   res
 }

--- a/man/bed_cluster.Rd
+++ b/man/bed_cluster.Rd
@@ -7,7 +7,7 @@
 bed_cluster(x, max_dist = 0)
 }
 \arguments{
-\item{x}{tbl of intervals}
+\item{x}{tbl of interval}
 
 \item{max_dist}{maximum distance between clustered intervals.}
 }
@@ -58,4 +58,3 @@ Other single-set-ops: \code{\link{bed_complement}},
   \code{\link{bed_random}}, \code{\link{bed_shift}},
   \code{\link{bed_shuffle}}, \code{\link{bed_slop}}
 }
-

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -16,6 +16,8 @@ DataFrame merge_impl(GroupedDataFrame gdf, int max_dist = 0) {
   IntegerVector starts   = df["start"] ;
   IntegerVector ends     = df["end"] ;
 
+  std::size_t cluster_id = 0; //store counter for cluster id
+
   GroupedDataFrame::group_iterator git = gdf.group_begin() ;
   for (int i=0; i<ng; i++, ++git) {
 
@@ -25,8 +27,6 @@ DataFrame merge_impl(GroupedDataFrame gdf, int max_dist = 0) {
 
     interval_t last_interval = interval_t(0,0,0) ;
 
-    int id, last_id = 0 ; // holds start of the first of intervals to be merged
-
     for (auto it : intervals) {
 
       auto idx = it.value ;
@@ -35,15 +35,15 @@ DataFrame merge_impl(GroupedDataFrame gdf, int max_dist = 0) {
       int overlap = intervalOverlap(it, last_interval) ;
       overlaps[idx] = overlap ;
 
-      id = it.start ;
-
+      // if overlaps or within max_dist assign to previous cluster
       if (overlap > 0) {
-        ids[idx] = last_id ;
+        ids[idx] = cluster_id ;
       } else if (overlap <= 0 && std::abs(overlap) <= max_dist) {
-        ids[idx] = last_id ;
+        ids[idx] = cluster_id ;
       } else {
-        ids[idx] = id ;
-        last_id = it.start ;
+        // increment cluster id and assign
+        ++cluster_id ;
+        ids[idx] = cluster_id ;
       }
 
       last_interval = it ;

--- a/tests/testthat/test_cluster.r
+++ b/tests/testthat/test_cluster.r
@@ -1,18 +1,18 @@
 context("bed_cluster")
 
 # https://github.com/arq5x/bedtools2/blob/master/test/cluster/test-cluster.sh
- 
+
 x <- tibble::tribble(
   ~chrom, ~start,  ~end,    ~name, ~id, ~strand,
   "chr1", 72017,   884436,  'a',   1,   '+',
-  "chr1", 72017,   844113,  'b',   2,   '+',   
-  "chr1", 939517,  1011278, 'c',   3,   '+',   
-  "chr1", 1142976, 1203168, 'd',   4,   '+',   
-  "chr1", 1153667, 1298845, 'e',   5,   '-',   
-  "chr1", 1153667, 1219633, 'f',   6,   '+',   
-  "chr1", 1155173, 1200334, 'g',   7,   '-',   
-  "chr1", 1229798, 1500664, 'h',   8,   '-',   
-  "chr1", 1297735, 1357056, 'i',   9,   '+',   
+  "chr1", 72017,   844113,  'b',   2,   '+',
+  "chr1", 939517,  1011278, 'c',   3,   '+',
+  "chr1", 1142976, 1203168, 'd',   4,   '+',
+  "chr1", 1153667, 1298845, 'e',   5,   '-',
+  "chr1", 1153667, 1219633, 'f',   6,   '+',
+  "chr1", 1155173, 1200334, 'g',   7,   '-',
+  "chr1", 1229798, 1500664, 'h',   8,   '-',
+  "chr1", 1297735, 1357056, 'i',   9,   '+',
   "chr1", 1844181, 1931789, 'j',   10,  '-'
 )
 
@@ -26,4 +26,23 @@ test_that("stranded cluster works", {
   res <- bed_cluster(group_by(x, strand))
   # test number of groups in output
   expect_equal(length(unique(res$.id)), 7)
+})
+
+x <- tibble::tribble(
+  ~chrom, ~start,  ~end,    ~name, ~id, ~strand,
+  "chr1", 72017,   884436,  'a',   1,   '+',
+  "chr1", 72017,   844113,  'b',   2,   '+',
+  "chr1", 939517,  1011278, 'c',   3,   '+',
+  "chr2", 940000,  990000,  'd',   4,   '-'
+)
+
+test_that("cluster ids are not repeated per group issue #171", {
+  res <- bed_cluster(x)
+  # test that groups have unique ids
+  chr1_ids <- filter(res, chrom == "chr1") %>%
+    select(.id) %>% unique() %>%  unlist()
+  chr2_ids <- filter(res, chrom == "chr2") %>%
+    select(.id) %>% unique() %>%  unlist()
+  shared_ids <- intersect(chr1_ids, chr2_ids)
+  expect_equal(length(shared_ids), 0)
 })


### PR DESCRIPTION
* track ids independent of groups in bed_cluster #171

* sort input by default to avoid additional explict sort

* fixes #171 
