### PR TITLE
Error in bed_shuffle() Issue176

### DIFF
--- a/inst/include/valr.h
+++ b/inst/include/valr.h
@@ -6,7 +6,7 @@
 #include "IntervalTree.h"
 #include <functional>
 #include <random>
-
+#include <stack>
 
 //[[Rcpp::depends(dplyr)]]
 //[[Rcpp::plugins(cpp11)]]

--- a/tests/testthat/test_cluster.r
+++ b/tests/testthat/test_cluster.r
@@ -19,13 +19,13 @@ x <- tibble::tribble(
 test_that("basic cluster works", {
   res <- bed_cluster(x)
   # test number of groups in output
-  expect_equal(length(unique(res$.id)), 5)
+  expect_equal(length(unique(res$.id)), 4)
 })
 
 test_that("stranded cluster works", {
   res <- bed_cluster(group_by(x, strand))
   # test number of groups in output
-  expect_equal(length(unique(res$.id)), 7)
+  expect_equal(length(unique(res$.id)), 6)
 })
 
 x <- tibble::tribble(

--- a/tests/testthat/test_merge.r
+++ b/tests/testthat/test_merge.r
@@ -7,9 +7,9 @@ test_that("merge on 1 chrom", {
     "chr1",    150,       250,
     "chr1",    200,       350
   )
-  
+
   res <- bed_merge(bed_df)
-  expect_equal(nrow(res), 1)   
+  expect_equal(nrow(res), 1)
 })
 
 test_that("merge with interval at start", {
@@ -19,9 +19,9 @@ test_that("merge with interval at start", {
     "chr1",    100,       200,
     "chr1",    150,       250
   )
-  
+
   res <- bed_merge(bed_df)
-  expect_equal(nrow(res), 2)   
+  expect_equal(nrow(res), 2)
 })
 
 test_that("merge with two chroms", {
@@ -32,9 +32,9 @@ test_that("merge with two chroms", {
     "chr2",    100,       200,
     "chr2",    150,       250
   )
-  
+
   res <- bed_merge(bed_df)
-  expect_equal(nrow(res), 2)   
+  expect_equal(nrow(res), 2)
 })
 
 test_that("book-ended intervals are merged", {
@@ -43,9 +43,9 @@ test_that("book-ended intervals are merged", {
     "chr1",    1,         50,
     "chr1",    50,        100
   )
-  
+
   res <- bed_merge(bed_df)
-  expect_equal(nrow(res), 1)   
+  expect_equal(nrow(res), 1)
 })
 
 test_that("max_dist is enforced", {
@@ -54,9 +54,9 @@ test_that("max_dist is enforced", {
     "chr1",    1,         50,
     "chr1",    50,        100
   )
-  
+
   res <- bed_merge(bed_df, max_dist = 1)
-  expect_equal(nrow(res), 1)   
+  expect_equal(nrow(res), 1)
 })
 
 test_that("max_dist is a positive value", {
@@ -65,12 +65,12 @@ test_that("max_dist is a positive value", {
     "chr1",    1,         50,
     "chr1",    50,        100
   )
-  
+
   expect_error(bed_merge(bed_df, max_dist = -1))
 })
 
 test_that("input groups are maintained in the output tbl issue #108",{
-  
+
   x <- tibble::tribble(
     ~chrom, ~start, ~end, ~group,
     'chr1', 100,    200,  'A',
@@ -78,8 +78,8 @@ test_that("input groups are maintained in the output tbl issue #108",{
     'chr1', 300,    500,  'A',
     'chr1', 125,    175,  'C',
     'chr1', 150,    200,  'B'
-  ) 
-  
+  )
+
   x <- arrange(x, chrom, start)
   x <- group_by(x, group)
   res <- bed_merge(x)
@@ -87,7 +87,7 @@ test_that("input groups are maintained in the output tbl issue #108",{
 })
 
 test_that("intervals can be merged by strand",{
-  
+
   x <- tibble::tribble(
     ~chrom, ~start, ~end, ~strand,
     'chr1', 100,    200,  '+',
@@ -95,15 +95,15 @@ test_that("intervals can be merged by strand",{
     'chr1', 300,    500,  '+',
     'chr1', 125,    175,  '-',
     'chr1', 150,    200,  '-'
-  ) 
-  
+  )
+
   x <- group_by(x, strand)
   res <- bed_merge(x)
   expect_equal(nrow(res), 2)
 })
 
 test_that("summaries can be computed issue #132",{
-  
+
   x <- tibble::tribble(
     ~chrom, ~start, ~end, ~value, ~strand,
     "chr1", 1,      50,   1,      '+',
@@ -114,14 +114,14 @@ test_that("summaries can be computed issue #132",{
     "chr2", 400,    500,  6,      '+',
     "chr2", 450,    550,  7,      '+'
   )
-  
+
   res <- bed_merge(x, .value = sum(value))
   expect_true(all(res$.value != "."))
   expect_true(all(res$.value == c(1, 5, 4, 18)))
 })
 
 test_that("multiple summaries can be computed issue #132",{
-  
+
   x <- tibble::tribble(
     ~chrom, ~start, ~end, ~value, ~strand,
     "chr1", 1,      50,   1,      '+',
@@ -132,9 +132,21 @@ test_that("multiple summaries can be computed issue #132",{
     "chr2", 400,    500,  6,      '+',
     "chr2", 450,    550,  7,      '+'
   )
-  
+
   res <- bed_merge(x, .value = sum(value), .min = min(value))
   expect_true(all(res$.value != "."))
   expect_true(all(res$.value == c(1, 5, 4, 18)))
   expect_true(all(res$.min == c(1, 2, 4, 5)))
+})
+
+test_that("contained intervals are merged issue #176", {
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    'chr1',  1,     10,
+    'chr1',  2,     5,
+    'chr1',  7,     9
+  )
+
+  res <- bed_merge(x)
+  expect_true(nrow(res) == 1)
 })


### PR DESCRIPTION
This PR contains a reimplementation of `merge_impl` which fixes #176 

  * The reimplementation is just as fast as the previous implementation
  * The tests for `bed_cluster()` were testing for the error, so I fixed the test
  * I also added an additional test for `bed_merge()` for contained intervals

```r
x <- tibble::tribble(
    ~chrom, ~start, ~end,
    'chr1',  1,     10,
    'chr1',  2,     5,
    'chr1',  7,     9
  )

bed_merge(x)
#>  # A tibble: 1 × 3
#>    chrom start   end
#>   <chr> <dbl> <dbl>
#>   1  chr1     1    10

```