### PR TITLE
bed_subtract reorganization and profiling #197 and #202

### DIFF
--- a/R/bed_subtract.r
+++ b/R/bed_subtract.r
@@ -1,29 +1,29 @@
 #' Subtract intervals.
-#' 
+#'
 #' Subtract \code{y} intervals from \code{x} intervals.
-#' 
+#'
 #' @param x tbl of intervals
 #' @param y tbl of intervals
 #' @param any remove any \code{x} intervals that overlap \code{y}
-#' 
+#'
 #' @template groups
-#' 
-#' @family multi-set-ops 
+#'
+#' @family multi-set-ops
 #' @seealso \url{http://bedtools.readthedocs.io/en/latest/content/tools/subtract.html}
-#' 
+#'
 #' @examples
 #' x <- tibble::tribble(
 #' ~chrom, ~start, ~end,
 #' 'chr1', 1,      100
 #' )
-#'  
+#'
 #' y <- tibble::tribble(
 #'   ~chrom, ~start, ~end,
 #'   'chr1', 50,     75
 #' )
-#'  
+#'
 #' bed_glyph(bed_subtract(x, y))
-#' 
+#'
 #' x <- tibble::tribble(
 #'  ~chrom, ~start, ~end,
 #'  "chr1", 100,    200,
@@ -32,7 +32,7 @@
 #'  "chr1", 1000,   1200,
 #'  "chr1", 1300,   1500
 #' )
-#' 
+#'
 #' y <- tibble::tribble(
 #'  ~chrom, ~start, ~end,
 #'  "chr1", 150,    175,
@@ -42,29 +42,35 @@
 #'  "chr1", 1150,   1250,
 #'  "chr1", 1299,   1501
 #' )
-#' 
+#'
 #' bed_subtract(x, y)
-#' 
+#'
 #' bed_subtract(x, y, any = TRUE)
-#'  
+#'
 #' @export
 bed_subtract <- function(x, y, any = FALSE) {
-  
+
   x <- group_by(x, chrom, add = TRUE)
   y <- bed_merge(y)
   y <- group_by(y, chrom, add = TRUE)
-    
+
+  # find groups not in y
+  not_y_grps <- setdiff(get_labels(x), get_labels(y))
+  # keep x ivls from groups not found in y
+  res_no_y <- semi_join(x, not_y_grps, by = colnames(not_y_grps))
+
   if (any) {
-    # collect and return x intervals without overlaps 
+    # collect and return x intervals without overlaps
     res <- bed_intersect(x, y)
     colspec <- c('chrom', 'start' = 'start.x', 'end' = 'end.x')
     anti <- anti_join(x, res, by = colspec)
-   
+
     return(anti)
   }
 
   res <- subtract_impl(x, y)
+  res <- bind_rows(res, res_no_y)
   res <- arrange(res, chrom, start)
 
-  res  
+  res
 }

--- a/R/bed_subtract.r
+++ b/R/bed_subtract.r
@@ -51,7 +51,6 @@
 bed_subtract <- function(x, y, any = FALSE) {
 
   x <- group_by(x, chrom, add = TRUE)
- # y <- bed_merge(y)
   y <- group_by(y, chrom, add = TRUE)
 
   # find groups not in y

--- a/R/bed_subtract.r
+++ b/R/bed_subtract.r
@@ -51,7 +51,7 @@
 bed_subtract <- function(x, y, any = FALSE) {
 
   x <- group_by(x, chrom, add = TRUE)
-  y <- bed_merge(y)
+ # y <- bed_merge(y)
   y <- group_by(y, chrom, add = TRUE)
 
   # find groups not in y

--- a/R/utils.r
+++ b/R/utils.r
@@ -1,10 +1,10 @@
 #' Provide working directory for valr example files.
-#' 
+#'
 #' @param path path to file
-#' 
-#' @examples 
+#'
+#' @examples
 #' valr_example('hg19.chrom.sizes.gz')
-#' 
+#'
 #' @export
 valr_example <- function(path) {
   # https://twitter.com/JennyBryan/status/780150538654527488
@@ -12,36 +12,36 @@ valr_example <- function(path) {
 }
 
 #' reformat tbl column ordering based upon another tbl
-#' 
-#' \code{format_bed} returns a tbl whose columns are ordered by another tbl. 
-#' The \code{x} tbl columns are reordered based on the \code{y} columns ordering.
-#' If there are \code{x} columns that do not exist in \code{y} they are moved to the last column. 
 #'
-#'  
+#' \code{format_bed} returns a tbl whose columns are ordered by another tbl.
+#' The \code{x} tbl columns are reordered based on the \code{y} columns ordering.
+#' If there are \code{x} columns that do not exist in \code{y} they are moved to the last column.
+#'
+#'
 #' @param x tbl of intervals
 #' @param y tbl of intervals
-#'  
+#'
 #' @examples
 #' x <- tibble::tribble(
 #'   ~end,  ~chrom,   ~start, ~value,
 #'   75,  "chr1",    125,    10
 #'  )
-#' 
+#'
 #' y <- tibble::tribble(
 #'   ~chrom,   ~start,    ~end,  ~scores,
 #'   "chr1",    50,       100,  1.2,
 #'   "chr1",    100,       150,  2.4
 #'   )
-#'   
-#' 
+#'
+#'
 #' format_bed(x, y)
 #' @noRd
 format_bed <- function(x, y) {
   names_x <- names(x)
   names_y <- names(y)
-  
+
   names_x <- names_x[order(match(names_x,names_y))]
-  
+
   x <- select(x, one_of(names_x))
   x
 }
@@ -54,37 +54,37 @@ format_bed <- function(x, y) {
 #'
 #' @param x tbl of intervals
 #' @param y tbl of intervals
-#'  
+#'
 #' @return \code{list} of groups or \code{NULL}
-#'  
+#'
 #' @examples
 #' x <- tibble::tribble(
 #'   ~chrom, ~start, ~end, ~value,
 #'   "chr1", 150,    400,  100,
 #'   "chr2", 230,    430,  200
 #' )
-#' 
+#'
 #' y <- tibble::tribble(
 #'   ~chrom, ~start, ~end, ~value,
 #'   "chr1", 50,     100,  1,
 #'   "chr1", 100,    150,  2
 #' )
-#'   
+#'
 #' x <- dplyr::group_by(x, chrom, value)
 #' y <- dplyr::group_by(y, chrom, value)
 #' shared_groups(x, y)
-#'  
+#'
 #' y <- dplyr::group_by(y, chrom)
 #' shared_groups(x, y)
-#' 
+#'
 #' y <- dplyr::ungroup(y)
 #' shared_groups(x, y)
 #' @noRd
 shared_groups <- function(x, y) {
-  
+
   groups_x <- groups(x)
   groups_y <- groups(y)
-  
+
   groups_xy <- intersect(groups_x, groups_y)
   if (length(groups_xy) == 0){
     groups_xy <- NULL
@@ -97,3 +97,9 @@ check_suffix <- function(suffix) {
   if (!is.character(suffix) || length(suffix) != 2)
     stop("`suffix` must be a character vector of length 2.", call. = FALSE)
 }
+
+#' Return group labels from tbl_df
+#' @param grp_df grouped tbl_df
+#' @return \code{tbl_df of grouping labels} or \code{NULL} if no groups present
+#' @noRd
+get_labels <- function(grp_tbl) attr(grp_tbl, "labels")

--- a/R/utils.r
+++ b/R/utils.r
@@ -100,6 +100,6 @@ check_suffix <- function(suffix) {
 
 #' Return group labels from tbl_df
 #' @param grp_df grouped tbl_df
-#' @return \code{tbl_df of grouping labels} or \code{NULL} if no groups present
+#' @return \code{tibble} of grouping labels or \code{NULL} if no groups present
 #' @noRd
 get_labels <- function(grp_tbl) attr(grp_tbl, "labels")

--- a/src/subtract.cpp
+++ b/src/subtract.cpp
@@ -37,9 +37,6 @@ void subtract_group(ivl_vector_t vx, ivl_vector_t vy,
     // sort overlaps by start not sure if necessary
     std::sort(overlaps.begin(), overlaps.end(), intervalStartSorter) ;
 
-    // keep track of the number of new intervals to generate
-    int new_ivl_count = 0;
-
     //iterate through overlaps with current x  interval
     // modifying start and stop as necessary
     for (auto oit : overlaps) {
@@ -47,23 +44,27 @@ void subtract_group(ivl_vector_t vx, ivl_vector_t vy,
       auto y_start = oit.start;
       auto y_stop = oit.stop;
 
-      if (y_start <= x_start) {
-        //advance x_start to end of y
-        x_start = std::min(y_stop, x_stop) ;
-        continue ;
-      } else if (y_start > x_start) {
+      if (x_start > x_stop) {
+        break ;
+      } else if (y_start <= x_start) {
+        // advance x_start to end of y unless y is shorter than x
+        if (x_start > y_stop) {
+          continue ;
+        } else {
+          x_start = y_stop ;
+        };
+      } else {
         // report new interval
         indices_out.push_back(it.value) ;
         starts_out.push_back(x_start) ;
         ends_out.push_back(y_start) ;
         // advance to end of y ivl
         x_start = y_stop;
-        new_ivl_count++ ;
-        continue ;
       }
     }
 
     if (x_start < x_stop) {
+      // report interval
       indices_out.push_back(it.value) ;
       starts_out.push_back(x_start) ;
       ends_out.push_back(x_stop) ;

--- a/tests/testthat/test_subtract.r
+++ b/tests/testthat/test_subtract.r
@@ -31,12 +31,12 @@ test_that("left dangling y intervals adjust x starts", {
     ~chrom, ~start, ~end,
     "chr1", 100,    200
   ) %>% group_by(chrom)
-  
+
   y <- tibble::tribble(
     ~chrom, ~start, ~end,
     "chr1", 75,    150
   ) %>% group_by(chrom)
-  
+
   res <- bed_subtract(x, y)
   expect_equal(res$start, 150)
 })
@@ -46,12 +46,12 @@ test_that("right dangling y intervals adjust x ends", {
     ~chrom, ~start, ~end,
     "chr1", 100,    200
   ) %>% group_by(chrom)
-  
+
   y <- tibble::tribble(
     ~chrom, ~start, ~end,
     "chr1", 175,    250
   ) %>% group_by(chrom)
-  
+
   res <- bed_subtract(x, y)
   expect_equal(res$end, 175)
 })
@@ -61,15 +61,15 @@ test_that("fully contained x intervals are removed", {
     ~chrom, ~start, ~end,
     "chr1", 100,    200
   ) %>% group_by(chrom)
-  
+
   y <- tibble::tribble(
     ~chrom, ~start, ~end,
     "chr1", 50,    250
   ) %>% group_by(chrom)
-  
+
   res <- bed_subtract(x, y)
   expect_equal(nrow(res), 0)
-  
+
 })
 
 test_that("subtractions from x bed_tbl with more chroms than y are captured", {
@@ -78,11 +78,11 @@ test_that("subtractions from x bed_tbl with more chroms than y are captured", {
     "chr1",    100,       200,
     "chr3",    400,       500
   )
-  
+
   y <- tibble::tribble(
     ~chrom,   ~start,    ~end,
-    "chr3",    425,       475) 
-  
+    "chr3",    425,       475)
+
   res <- bed_subtract(x, y)
   expect_true("chr3" %in% res$chrom)
 })
@@ -93,11 +93,11 @@ test_that("non-overlapping intervals from different chrom are not dropped", {
     "chr1",    100,       200,
     "chr3",    400,       500
   )
-  
+
   y <- tibble::tribble(
     ~chrom,   ~start,    ~end,
-    "chr3",    425,       475) 
-  
+    "chr3",    425,       475)
+
   res <- bed_subtract(x, y)
   expect_true("chr1" %in% res$chrom)
 })
@@ -107,7 +107,7 @@ a <- tibble::tribble(
   "chr1",	10,	20,	"a1",	1,	"+",
   "chr1",	50,	70,	"a2",	2,	"-"
 )
-  
+
 b <- tibble::tribble(
   ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
   "chr1",	18,	25,	"b1",	1,	"-",
@@ -120,3 +120,18 @@ test_that("tbls grouped by strand are processed", {
   expect_true(all(res == a))
 })
 
+test_that("longest merged y intervals are used for subtraction", {
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    "chr1", 500,    600
+  )
+
+  y <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    "chr1", 510,    580,
+    "chr1", 550,    575
+  )
+
+  res <- bed_subtract(x, y)
+  expect_true(max(res$start) == 580)
+})


### PR DESCRIPTION
For #197 

Major Changes:
- Removed the Cpp code checking for `x` interval groups not found in `y`. This was done by using a join on the R side on the group labels found in `x` and not in `y`. 
- Use`GroupApply` to call`subtract_grouped`. 

Minor Changes:
- Added a utility function `get_labels` which returns the `labels` attribute from `attr()` for grouped tbls. 

For #202 

I was able to speed up `bed_substract()` almost 2x.

Major Changes:
- The two slowest steps for `bed_subtract()` are the calls to `bed_merge()` and `subtract_impl`.  I removed the call to `bed_merge()` on the R-side and instead changed the logic of `subtract_grouped` on the cpp-side to handle overlapping `y` intervals. 

Minor Changes:
- Added a test to check if overlapping y-intervals would be treated as merged. 

```r
library(valr)
x <- bed_random(read_genome(valr_example("genome.txt.gz")))
y <- bed_random(read_genome(valr_example("genome.txt.gz")))

# on current master
microbenchmark::microbenchmark(bed_subtract(x, y), unit = 's', times = 1)
#> Unit: seconds
#> expr     min      lq    mean  median      uq     max neval
#> bed_subtract(x, y) 2.41849 2.41849 2.41849 2.41849 2.41849 2.41849     1

# with proposed changes
microbenchmark::microbenchmark(bed_subtract(x, y), unit = 's', times = 1)
#> Unit: seconds
#> expr      min       lq     mean   median       uq      max neval
#> bed_subtract(x, y) 1.281127 1.281127 1.281127 1.281127 1.281127 1.281127     1
```
