### PR TITLE
dplyr 0.6.0 release compatibility fixes #240

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # valr 0.2.0.9000
 
+## Bug fixes
+
+* quote `dplyr::everything()` when called in SE variant of `deplyr::select()` (fixes #240)
+
 # valr 0.2.0
 
 ## Major changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # valr 0.2.0.9000
 
 ## Bug fixes
-
-* quote `dplyr::everything()` when called in SE variant of `deplyr::select()` (fixes #240)
+* minor vignette fixes and changes to `bed_makewindows()` and `bed_random()` for dplyr0.6.0 compatibilty (fixes #242)
+* quote `dplyr::everything()` when called in SE variant of `dplyr::select()` (fixes #240)
 
 # valr 0.2.0
 

--- a/R/bed_intersect.r
+++ b/R/bed_intersect.r
@@ -113,7 +113,7 @@ bed_intersect <- function(x, ..., invert = FALSE, suffix = c('.x', '.y')) {
     multiple_tbls <- TRUE
     #bind_rows preserves grouping
     y <- bind_rows(y_tbl, .id = ".source")
-    y <- select_(y, "-.source", everything(), ".source")
+    y <- select_(y, "-.source", ~everything(), ".source")
   } else {
     # only one tbl supplied, so extract out single tbl from list
     y <- y_tbl[[1]]

--- a/R/bed_makewindows.r
+++ b/R/bed_makewindows.r
@@ -68,6 +68,8 @@ bed_makewindows <- function(x, genome, win_size = 0,
   res <- mutate(x, .start = list(seq(start, end,
                                      by = .win_size - step_size)),
                 .win_num = list(seq(1, length(.start))))
+  # can't unnest if grouped by row
+  res <- ungroup(res)
   res <- tidyr::unnest(res)
   res <- mutate(res, .end = ifelse(.start + .win_size < end,
                                    .start + .win_size, end))

--- a/R/bed_map.r
+++ b/R/bed_map.r
@@ -56,7 +56,7 @@
 #' bed_map(x, y, .concat = concat(value))
 #'
 #' # can also create a list-col
-#' bed_map(x, y, .values = tibble::tibble(value))
+#' bed_map(x, y, .values = list(value))
 #'
 #' # can also use `nth` family from dplyr
 #' bed_map(x, y, .first = dplyr::first(value))

--- a/R/bed_random.r
+++ b/R/bed_random.r
@@ -41,7 +41,7 @@ bed_random <- function(genome, length = 1000, n = 1e6, sort_by = c('chrom', 'sta
   out <- random_impl(genome, length, n, seed)
 
   if (!is.null(sort_by) && length(sort_by) > 0)
-    out <- arrange_(out, .dots = sort_by)
+    out <- arrange_(out, sort_by)
 
   out <- tibble::as_tibble(out)
   out

--- a/man/bed_map.Rd
+++ b/man/bed_map.Rd
@@ -85,7 +85,7 @@ bed_map(x, y, .min = min(value), .max = max(value))
 bed_map(x, y, .concat = concat(value))
 
 # can also create a list-col
-bed_map(x, y, .values = tibble::tibble(value))
+bed_map(x, y, .values = list(value))
 
 # can also use `nth` family from dplyr
 bed_map(x, y, .first = dplyr::first(value))

--- a/vignettes/interval-stats.Rmd
+++ b/vignettes/interval-stats.Rmd
@@ -191,7 +191,8 @@ pvals_coding <- projection_stats(rpts, promoters_coding, genome, 'name', 'coding
 pvals_ncoding <- projection_stats(rpts, promoters_ncoding, genome, 'name', 'non_coding')
 
 pvals <-
-  bind_rows(pvals_ncoding, pvals_coding) %>% 
+  bind_rows(pvals_ncoding, pvals_coding) %>%
+  ungroup() %>% 
   tidyr::unnest() %>%
   select(-chrom)
 

--- a/vignettes/valr.Rmd
+++ b/vignettes/valr.Rmd
@@ -70,7 +70,7 @@ nearby %>%
 
 Remote databases can be accessed with `db_ucsc()` (to access the UCSC Browser) and `db_ensembl()` (to access Ensembl databases).
 
-```{r db, warning = F}
+```{r db, warning = F, eval = F}
 # access the `refGene` tbl on the `hg38` assembly.
 if(require(RMySQL)) {
   ucsc <- db_ucsc('hg38')


### PR DESCRIPTION
This PR addresses minor changes needed to build `valr` using `dply` at [v.0.6.0-rc](https://github.com/tidyverse/dplyr/releases/tag/v0.6.0-rc)

  - `dplyr::everything()` should be quoted in SE dplyr functions (#240)
  -  grouped tbls need to be ungrouped prior to unnesting to avoid error in `unnest()`:
``Column `.start`: must be length one (the group size), not 11``
  -  `arrange_()` failed to recognized `.dots` argument in `bed_random()` resulting in a failure to sort the output
  -  `bind_rows()` in `bed_map()` not accepting list-cols with `tibbles`, but works fine with `lists`
  -  passes R CMD check with dplyr v0.5.0 and dplyr v0.6.0-rc
  - closes #240 and #242
