### PR TITLE
speeding up bed_merge() related to  Issue214 and 210

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,42 +2,42 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 absdist_impl <- function(x, y) {
-    .Call('valr_absdist_impl', PACKAGE = 'valr', x, y)
+    .Call(valr_absdist_impl, x, y)
 }
 
 closest_impl <- function(x, y, suffix_x, suffix_y) {
-    .Call('valr_closest_impl', PACKAGE = 'valr', x, y, suffix_x, suffix_y)
+    .Call(valr_closest_impl, x, y, suffix_x, suffix_y)
 }
 
 complement_impl <- function(gdf, genome) {
-    .Call('valr_complement_impl', PACKAGE = 'valr', gdf, genome)
+    .Call(valr_complement_impl, gdf, genome)
 }
 
 coverage_impl <- function(x, y) {
-    .Call('valr_coverage_impl', PACKAGE = 'valr', x, y)
+    .Call(valr_coverage_impl, x, y)
 }
 
 intersect_impl <- function(x, y, suffix_x = ".x", suffix_y = ".y") {
-    .Call('valr_intersect_impl', PACKAGE = 'valr', x, y, suffix_x, suffix_y)
+    .Call(valr_intersect_impl, x, y, suffix_x, suffix_y)
 }
 
 merge_impl <- function(gdf, max_dist = 0L, collapse = TRUE) {
-    .Call('valr_merge_impl', PACKAGE = 'valr', gdf, max_dist, collapse)
+    .Call(valr_merge_impl, gdf, max_dist, collapse)
 }
 
 random_impl <- function(genome, length, n, seed = 0L, col_chrom = "chrom", col_size = "size") {
-    .Call('valr_random_impl', PACKAGE = 'valr', genome, length, n, seed, col_chrom, col_size)
+    .Call(valr_random_impl, genome, length, n, seed, col_chrom, col_size)
 }
 
 reldist_impl <- function(x, y) {
-    .Call('valr_reldist_impl', PACKAGE = 'valr', x, y)
+    .Call(valr_reldist_impl, x, y)
 }
 
 shuffle_impl <- function(df, incl, within = FALSE, max_tries = 1000L, seed = 0L) {
-    .Call('valr_shuffle_impl', PACKAGE = 'valr', df, incl, within, max_tries, seed)
+    .Call(valr_shuffle_impl, df, incl, within, max_tries, seed)
 }
 
 subtract_impl <- function(gdf_x, gdf_y) {
-    .Call('valr_subtract_impl', PACKAGE = 'valr', gdf_x, gdf_y)
+    .Call(valr_subtract_impl, gdf_x, gdf_y)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -21,12 +21,8 @@ intersect_impl <- function(x, y, suffix_x = ".x", suffix_y = ".y") {
     .Call('valr_intersect_impl', PACKAGE = 'valr', x, y, suffix_x, suffix_y)
 }
 
-timesTwo <- function(x) {
-    .Call('valr_timesTwo', PACKAGE = 'valr', x)
-}
-
-merge_impl <- function(gdf, max_dist = 0L, dots = FALSE) {
-    .Call('valr_merge_impl', PACKAGE = 'valr', gdf, max_dist, dots)
+merge_impl <- function(gdf, max_dist = 0L, collapse = TRUE) {
+    .Call('valr_merge_impl', PACKAGE = 'valr', gdf, max_dist, collapse)
 }
 
 random_impl <- function(genome, length, n, seed = 0L, col_chrom = "chrom", col_size = "size") {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -21,8 +21,12 @@ intersect_impl <- function(x, y, suffix_x = ".x", suffix_y = ".y") {
     .Call('valr_intersect_impl', PACKAGE = 'valr', x, y, suffix_x, suffix_y)
 }
 
-merge_impl <- function(gdf, max_dist = 0L) {
-    .Call('valr_merge_impl', PACKAGE = 'valr', gdf, max_dist)
+timesTwo <- function(x) {
+    .Call('valr_timesTwo', PACKAGE = 'valr', x)
+}
+
+merge_impl <- function(gdf, max_dist = 0L, dots = FALSE) {
+    .Call('valr_merge_impl', PACKAGE = 'valr', gdf, max_dist, dots)
 }
 
 random_impl <- function(genome, length, n, seed = 0L, col_chrom = "chrom", col_size = "size") {

--- a/R/bed_cluster.r
+++ b/R/bed_cluster.r
@@ -48,7 +48,7 @@ bed_cluster <- function(x, max_dist = 0) {
   res <- group_by(x, chrom, add = TRUE)
   res <- arrange(res, chrom, start)
 
-  res <- merge_impl(res, max_dist, dots = TRUE)
+  res <- merge_impl(res, max_dist, collapse = FALSE)
 
   res <- mutate(res, .id = .id_merge)
   res <- select(res, -.id_merge, -.overlap_merge)

--- a/R/bed_cluster.r
+++ b/R/bed_cluster.r
@@ -48,7 +48,7 @@ bed_cluster <- function(x, max_dist = 0) {
   res <- group_by(x, chrom, add = TRUE)
   res <- arrange(res, chrom, start)
 
-  res <- merge_impl(res, max_dist)
+  res <- merge_impl(res, max_dist, dots = TRUE)
 
   res <- mutate(res, .id = .id_merge)
   res <- select(res, -.id_merge, -.overlap_merge)

--- a/R/bed_merge.r
+++ b/R/bed_merge.r
@@ -61,19 +61,24 @@ bed_merge <- function(x, max_dist = 0, ...) {
 
   res <- group_by(res, chrom, add = TRUE)
 
-  res <- merge_impl(res, max_dist)
-
   dots <- list(.start = ~min(start), .end = ~max(end))
-  dots <- c(dots, lazyeval::lazy_dots(...))
 
-  res <- group_by_(res, .dots = c("chrom", ".id_merge", x_groups), add = TRUE)
+  # if no dots are passed then use fast internal merge
+   if (length(list(...)) > 0) {
+     res <- merge_impl(res, max_dist, dots = TRUE)
+     dots <- c(dots, lazyeval::lazy_dots(...))
+     res <- group_by_(res, .dots = c("chrom", ".id_merge", x_groups), add = TRUE)
+     res <- summarize_(res, .dots = dots)
+     res <- rename(res, start = .start, end = .end)
+     res <- ungroup(res)
+     res <- select(res, -.id_merge)
+   } else {
+     res <- merge_impl(res, max_dist, dots = FALSE)
+     res <- select_(res, .dots = c("chrom", "start", "end", x_groups))
+  }
 
-  res <- summarize_(res, .dots = dots)
-  res <- rename(res, start = .start, end = .end)
-  res <- ungroup(res)
   # restore original grouping
   res <- group_by_(res, .dots = x_groups)
-  res <- select(res, -.id_merge)
   res <- reorder_names(res, x)
 
   attr(res, 'merged') <- TRUE

--- a/R/bed_merge.r
+++ b/R/bed_merge.r
@@ -64,8 +64,8 @@ bed_merge <- function(x, max_dist = 0, ...) {
   dots <- list(.start = ~min(start), .end = ~max(end))
 
   # if no dots are passed then use fast internal merge
-   if (length(list(...)) > 0) {
-     res <- merge_impl(res, max_dist, dots = TRUE)
+  if (!is.null(substitute(...))) {
+     res <- merge_impl(res, max_dist, collapse = FALSE)
      dots <- c(dots, lazyeval::lazy_dots(...))
      res <- group_by_(res, .dots = c("chrom", ".id_merge", x_groups), add = TRUE)
      res <- summarize_(res, .dots = dots)
@@ -73,7 +73,7 @@ bed_merge <- function(x, max_dist = 0, ...) {
      res <- ungroup(res)
      res <- select(res, -.id_merge)
    } else {
-     res <- merge_impl(res, max_dist, dots = FALSE)
+     res <- merge_impl(res, max_dist, collapse = TRUE)
      res <- select_(res, .dots = c("chrom", "start", "end", x_groups))
   }
 

--- a/inst/include/valr.h
+++ b/inst/include/valr.h
@@ -12,7 +12,6 @@
 
 #include <random>
 #include <functional>
-#include <stack>
 
 // [[Rcpp::plugins(cpp11)]]
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -70,15 +70,27 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// timesTwo
+NumericVector timesTwo(NumericVector x);
+RcppExport SEXP valr_timesTwo(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericVector >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(timesTwo(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // merge_impl
-DataFrame merge_impl(GroupedDataFrame gdf, int max_dist);
-RcppExport SEXP valr_merge_impl(SEXP gdfSEXP, SEXP max_distSEXP) {
+DataFrame merge_impl(GroupedDataFrame gdf, int max_dist, bool dots);
+RcppExport SEXP valr_merge_impl(SEXP gdfSEXP, SEXP max_distSEXP, SEXP dotsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< GroupedDataFrame >::type gdf(gdfSEXP);
     Rcpp::traits::input_parameter< int >::type max_dist(max_distSEXP);
-    rcpp_result_gen = Rcpp::wrap(merge_impl(gdf, max_dist));
+    Rcpp::traits::input_parameter< bool >::type dots(dotsSEXP);
+    rcpp_result_gen = Rcpp::wrap(merge_impl(gdf, max_dist, dots));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -70,27 +70,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// timesTwo
-NumericVector timesTwo(NumericVector x);
-RcppExport SEXP valr_timesTwo(SEXP xSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< NumericVector >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(timesTwo(x));
-    return rcpp_result_gen;
-END_RCPP
-}
 // merge_impl
-DataFrame merge_impl(GroupedDataFrame gdf, int max_dist, bool dots);
-RcppExport SEXP valr_merge_impl(SEXP gdfSEXP, SEXP max_distSEXP, SEXP dotsSEXP) {
+DataFrame merge_impl(GroupedDataFrame gdf, int max_dist, bool collapse);
+RcppExport SEXP valr_merge_impl(SEXP gdfSEXP, SEXP max_distSEXP, SEXP collapseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< GroupedDataFrame >::type gdf(gdfSEXP);
     Rcpp::traits::input_parameter< int >::type max_dist(max_distSEXP);
-    Rcpp::traits::input_parameter< bool >::type dots(dotsSEXP);
-    rcpp_result_gen = Rcpp::wrap(merge_impl(gdf, max_dist, dots));
+    Rcpp::traits::input_parameter< bool >::type collapse(collapseSEXP);
+    rcpp_result_gen = Rcpp::wrap(merge_impl(gdf, max_dist, collapse));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/init.c
+++ b/src/init.c
@@ -1,15 +1,3 @@
-// init.c
-//
-// Copyright (C) 2016 - 2017 Jay Hesselberth and Kent Riemondy
-//
-// This file is part of valr.
-//
-// This software may be modified and distributed under the terms
-// of the MIT license. See the LICENSE file for details.
-
-// DO NOT EDIT. created automatically from R >=3.4.0 using
-// tools::package_native_routine_registration_skeleton('.')
-
 #include <R.h>
 #include <Rinternals.h>
 #include <stdlib.h> // for NULL
@@ -25,11 +13,12 @@ extern SEXP valr_closest_impl(SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_complement_impl(SEXP, SEXP);
 extern SEXP valr_coverage_impl(SEXP, SEXP);
 extern SEXP valr_intersect_impl(SEXP, SEXP, SEXP, SEXP);
-extern SEXP valr_merge_impl(SEXP, SEXP);
+extern SEXP valr_merge_impl(SEXP, SEXP, SEXP);
 extern SEXP valr_random_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_reldist_impl(SEXP, SEXP);
 extern SEXP valr_shuffle_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_subtract_impl(SEXP, SEXP);
+extern SEXP valr_timesTwo(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"valr_absdist_impl",    (DL_FUNC) &valr_absdist_impl,    2},
@@ -37,11 +26,12 @@ static const R_CallMethodDef CallEntries[] = {
   {"valr_complement_impl", (DL_FUNC) &valr_complement_impl, 2},
   {"valr_coverage_impl",   (DL_FUNC) &valr_coverage_impl,   2},
   {"valr_intersect_impl",  (DL_FUNC) &valr_intersect_impl,  4},
-  {"valr_merge_impl",      (DL_FUNC) &valr_merge_impl,      2},
+  {"valr_merge_impl",      (DL_FUNC) &valr_merge_impl,      3},
   {"valr_random_impl",     (DL_FUNC) &valr_random_impl,     6},
   {"valr_reldist_impl",    (DL_FUNC) &valr_reldist_impl,    2},
   {"valr_shuffle_impl",    (DL_FUNC) &valr_shuffle_impl,    5},
   {"valr_subtract_impl",   (DL_FUNC) &valr_subtract_impl,   2},
+  {"valr_timesTwo",        (DL_FUNC) &valr_timesTwo,        1},
   {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -18,7 +18,6 @@ extern SEXP valr_random_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_reldist_impl(SEXP, SEXP);
 extern SEXP valr_shuffle_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_subtract_impl(SEXP, SEXP);
-extern SEXP valr_timesTwo(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"valr_absdist_impl",    (DL_FUNC) &valr_absdist_impl,    2},
@@ -31,7 +30,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"valr_reldist_impl",    (DL_FUNC) &valr_reldist_impl,    2},
   {"valr_shuffle_impl",    (DL_FUNC) &valr_shuffle_impl,    5},
   {"valr_subtract_impl",   (DL_FUNC) &valr_subtract_impl,   2},
-  {"valr_timesTwo",        (DL_FUNC) &valr_timesTwo,        1},
   {NULL, NULL, 0}
 };
 

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -9,11 +9,60 @@
 
 #include "valr.h"
 
-//[[Rcpp::export]]
-DataFrame merge_impl(GroupedDataFrame gdf, int max_dist = 0, bool dots = false ) {
+DataFrame collapseMergedIntervals(const GroupedDataFrame& gdf, int max_dist = 0 ) {
 
   auto ng = gdf.ngroups() ;
+  DataFrame df = gdf.data() ;
 
+  GroupedDataFrame::group_iterator git = gdf.group_begin() ;
+  // approach from http://www.geeksforgeeks.org/merging-intervals/
+
+  std::vector<ivl_t> s ;
+  for (int i = 0; i < ng; i++, ++git) {
+
+    SlicingIndex indices = *git ;
+
+    ivl_vector_t intervals = makeIntervalVector(df, indices);
+
+    // set first interval
+    s.push_back(intervals[0]) ;
+    intervals.erase(intervals.begin()) ;
+    for (auto it : intervals) {
+
+      auto top = s.back() ;
+      if (top.stop + max_dist < it.start) {
+        // no overlap push to stack and get new id
+        s.push_back(it) ;
+      }
+
+      else if (top.stop + max_dist < it.stop) {
+        // overlaps and need to update stack top position
+        // do not update id
+        top.stop = it.stop ;
+        s.pop_back() ;
+        s.push_back(top) ;
+      }
+    }
+  }
+
+  std::vector<int> indices_x ;
+  std::vector<int> group_starts ;
+  std::vector<int> group_ends ;
+  // interate through vector of merged intervals and write to dataframe
+  for (auto it:s) {
+    indices_x.push_back(it.value) ;
+    group_starts.push_back(it.start) ;
+    group_ends.push_back(it.stop) ;
+  }
+  DataFrame subset_x = DataFrameSubsetVisitors(df, names(df)).subset(indices_x, "data.frame");
+  subset_x["start"] = group_starts ;
+  subset_x["end"] = group_ends ;
+  return subset_x ;
+  }
+
+DataFrame clusterMergedIntervals(const GroupedDataFrame& gdf, int max_dist = 0){
+
+  auto ng = gdf.ngroups() ;
   DataFrame df = gdf.data() ;
 
   auto nr = df.nrows() ;
@@ -28,41 +77,40 @@ DataFrame merge_impl(GroupedDataFrame gdf, int max_dist = 0, bool dots = false )
 
   // approach from http://www.geeksforgeeks.org/merging-intervals/
 
-  std::stack<ivl_t> s ;
+  std::vector<ivl_t> s ;
 
   for (int i = 0; i < ng; i++, ++git) {
 
     SlicingIndex indices = *git ;
 
     ivl_vector_t intervals = makeIntervalVector(df, indices);
-
+    // set dummy first interval to ensure first interval maintained
     ivl_t last_interval = ivl_t(0, 0, 0) ;
-
-    s.push(intervals[0]) ;
-    intervals.erase(intervals.begin()) ;
+    s.push_back(last_interval) ;
     for (auto it : intervals) {
-
+      // get index to store cluster ids in vector
       auto idx = it.value ;
 
+      // get overlap distances and assign at proper index
       int overlap = intervalOverlap(it, last_interval) ;
       overlaps[idx] = overlap ;
-      last_interval = it ;
 
-      auto top = s.top() ;
+      last_interval = it ; // set interval to compare
+      auto top = s.back() ; // last good interval
       if (top.stop + max_dist < it.start) {
-        // no overlap push to stack and get new id
-        s.push(it) ;
+        // no overlap push to end of vector and get new id
+        s.push_back(it) ;
         cluster_id++ ;
-        ids[idx] = cluster_id ;
+        ids[idx] = cluster_id ; // assign cluster id at proper index
       }
 
       else if (top.stop + max_dist < it.stop) {
         // overlaps and need to update stack top position
         // do not update id
-        top.stop = it.stop ;
-        s.pop() ;
-        s.push(top) ;
-        ids[idx] = cluster_id ;
+        top.stop = it.stop ; // update end position
+        s.pop_back() ; // remove best end
+        s.push_back(top) ; // update end interval
+        ids[idx] = cluster_id ; // assign cluster id at proper inde
       }
 
       else {
@@ -71,26 +119,6 @@ DataFrame merge_impl(GroupedDataFrame gdf, int max_dist = 0, bool dots = false )
         ids[idx] = cluster_id ;
       }
     }
-  }
-
-  // store indices to keep if internal merge
-  if(!dots){
-    std::vector<int> indices_x ;
-    std::vector<int> group_starts ;
-    std::vector<int> group_ends ;
-    while (!s.empty())
-    {
-      ivl_t t = s.top();
-      indices_x.push_back(t.value) ;
-      group_starts.push_back(t.start) ;
-      group_ends.push_back(t.stop) ;
-      s.pop();
-    }
-    DataFrame subset_x = DataFrameSubsetVisitors(df, names(df)).subset(indices_x, "data.frame");
-    subset_x["start"] = group_starts ;
-    subset_x["end"] = group_ends ;
-
-    return subset_x ;
   }
 
   // add two new columns, ids and overlaps
@@ -118,6 +146,22 @@ DataFrame merge_impl(GroupedDataFrame gdf, int max_dist = 0, bool dots = false )
   out.attr("names") = names ;
 
   return out ;
+}
+
+//[[Rcpp::export]]
+DataFrame merge_impl(GroupedDataFrame gdf,
+                     int max_dist = 0,
+                     bool collapse = true ) {
+
+  if(!collapse) {
+    // return a cluster id per input interval
+    DataFrame out = clusterMergedIntervals(gdf, max_dist) ;
+    return out ;
+  } else {
+    // return only merged intervals
+    DataFrame out = collapseMergedIntervals(gdf, max_dist) ;
+    return out ;
+  }
 }
 
 /*** R


### PR DESCRIPTION
Some improvements to the speed of `bed_merge()`. 

Implemented an internal merge that is very fast. The current bottleneck is the sorting of the input tbl. I'll port this strategy to the rlang branch if this approach looks good. 

Here's a link to the [profiling](http://rpubs.com/kriemo/279213) for running `bed_merge()` on a million random intervals.


Timing for proposed changes:
``` r
library(valr)
library(tidyverse)
#> Loading tidyverse: ggplot2
#> Loading tidyverse: tibble
#> Loading tidyverse: tidyr
#> Loading tidyverse: readr
#> Loading tidyverse: purrr
#> Loading tidyverse: dplyr
#> Conflicts with tidy packages ----------------------------------------------
#> filter(): dplyr, stats
#> lag():    dplyr, stats
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

seed <- 1010486

x <- bed_random(genome, n = 1e6, seed = seed)
microbenchmark::microbenchmark(bed_merge(x), times = 1, unit = 's')
#> Unit: seconds
#>          expr       min        lq      mean    median        uq       max
#>  bed_merge(x) 0.4426746 0.4426746 0.4426746 0.4426746 0.4426746 0.4426746
#>  neval
#>      1
```

Timing on current master branch:
``` r
library(valr)
library(tidyverse)
#> Loading tidyverse: ggplot2
#> Loading tidyverse: tibble
#> Loading tidyverse: tidyr
#> Loading tidyverse: readr
#> Loading tidyverse: purrr
#> Loading tidyverse: dplyr
#> Conflicts with tidy packages ----------------------------------------------
#> filter(): dplyr, stats
#> lag():    dplyr, stats
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

seed <- 1010486

x <- bed_random(genome, n = 1e6, seed = seed)
microbenchmark::microbenchmark(bed_merge(x), times = 1, unit = 's')
#> Unit: seconds
#>          expr      min       lq     mean   median       uq      max neval
#>  bed_merge(x) 1.313616 1.313616 1.313616 1.313616 1.313616 1.313616     1
```

``` r
library(valr)
library(tidyverse)
#> Loading tidyverse: ggplot2
#> Loading tidyverse: tibble
#> Loading tidyverse: tidyr
#> Loading tidyverse: readr
#> Loading tidyverse: purrr
#> Loading tidyverse: dplyr
#> Conflicts with tidy packages ----------------------------------------------
#> filter(): dplyr, stats
#> lag():    dplyr, stats
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

seed <- 1010486

x <- bed_random(genome, n = 1e6, seed = seed)
y <- bed_random(genome, n = 1e6, seed = seed)

res <- microbenchmark(
  bed_random(genome, seed = seed), bed_closest(x, y),
  bed_intersect(x, y), bed_merge(x),
  bed_subtract(x, y), bed_complement(x, genome),
  bed_shuffle(x, genome, seed = seed),
  bed_absdist(x, y, genome), bed_reldist(x, y),
  bed_jaccard(x, y), bed_fisher(x, y, genome),
  times = 1,
  unit = 's')

# from unexported microbenchmark::convert_to_unit
res$ntime <- res$time / 1e9 

ggplot(res, aes(y=reorder(expr, ntime), x=ntime)) +
  geom_point(color='red', size=4) +
  xlab('execution time (seconds)') + ylab('') +
  theme_bw()
```

![](http://i.imgur.com/MDLk3Ds.png)