### PR TITLE
bed_closest() optimization issue210

### DIFF
--- a/R/bed_closest.r
+++ b/R/bed_closest.r
@@ -87,10 +87,6 @@ bed_closest <- function(x, y, overlap = TRUE,
 
   res <- closest_impl(x, y, suffix$x, suffix$y)
 
-  # remove negative overlap information
-  # not necessary to keep, due to distance column
-  res$.overlap <- ifelse(res$.overlap < 0, 0, res$.overlap )
-
   if (!overlap){
     res <- filter(res, .overlap < 1)
     res <- select(res, -.overlap)

--- a/src/closest.cpp
+++ b/src/closest.cpp
@@ -19,21 +19,21 @@ void closest_grouped(ivl_vector_t& vx, ivl_vector_t& vy,
   // initiatialize maximum left and right distances to minimize for closest
   int max_end = std::max(vx.back().stop, vy.back().stop) ;
 
-  for (auto vx_it : vx) {
+  for (auto const &vx_it : vx) {
     ivl_vector_t closest ;
     ivl_vector_t closest_ivls ;
 
     min_dist = std::make_pair(max_end, closest_ivls) ;
     tree_y.findClosest(vx_it.start, vx_it.stop, closest, min_dist) ;
 
-    for (auto ov_it : closest) {
+    for (auto const &ov_it : closest) {
 
       auto overlap = intervalOverlap(vx_it, ov_it) ;
 
       if (overlap > 0) {
         indices_x.push_back(vx_it.value) ;
         indices_y.push_back(ov_it.value) ;
-        overlap_sizes.push_back(overlap) ;
+        overlap_sizes.push_back(overlap < 0 ? -overlap : overlap) ;
         distance_sizes.push_back(0);
       } else if (ov_it.start > vx_it.stop) {
         indices_x.push_back(vx_it.value) ;
@@ -64,6 +64,12 @@ DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y,
   std::vector<int> indices_y ;
   std::vector<int> overlap_sizes ;
   std::vector<int> distance_sizes ;
+
+  // preallocate vector to save some time
+  indices_x.reserve(2e6) ;
+  indices_y.reserve(2e6) ;
+  overlap_sizes.reserve(2e6) ;
+  distance_sizes.reserve(2e6) ;
 
   // set up interval trees for each chromosome and apply closest_grouped
   GroupApply(x, y, closest_grouped, std::ref(indices_x), std::ref(indices_y),


### PR DESCRIPTION
A minor performance gain (~10%) by moving an `ifelse` statement to cpp and adding some preallocation for large vectors. 

``` r
library(valr)
library(tidyverse)
#> Loading tidyverse: ggplot2
#> Loading tidyverse: tibble
#> Loading tidyverse: tidyr
#> Loading tidyverse: readr
#> Loading tidyverse: purrr
#> Loading tidyverse: dplyr
#> Conflicts with tidy packages ----------------------------------------------
#> filter(): dplyr, stats
#> lag():    dplyr, stats
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

seed <- 1010486

x <- bed_random(genome, n = 1e6, seed = seed)
y <- bed_random(genome, n = 1e6, seed = seed)
microbenchmark::microbenchmark(bed_closest(x, y), unit = 's', times = 1)
#> Unit: seconds
#>               expr     min      lq    mean  median      uq     max neval
#>  bed_closest(x, y) 1.91765 1.91765 1.91765 1.91765 1.91765 1.91765     1
```

``` r
library(valr)
library(tidyverse)
#> Loading tidyverse: ggplot2
#> Loading tidyverse: tibble
#> Loading tidyverse: tidyr
#> Loading tidyverse: readr
#> Loading tidyverse: purrr
#> Loading tidyverse: dplyr
#> Conflicts with tidy packages ----------------------------------------------
#> filter(): dplyr, stats
#> lag():    dplyr, stats
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

seed <- 1010486

x <- bed_random(genome, n = 1e6, seed = seed)
y <- bed_random(genome, n = 1e6, seed = seed)
microbenchmark::microbenchmark(bed_closest(x, y), unit = 's', times = 1)

#> Unit: seconds
#>               expr      min       lq     mean   median       uq      max
#>  bed_closest(x, y) 2.187993 2.187993 2.187993 2.187993 2.187993 2.187993
#>  neval
#>      1
```
