### PR TITLE
speed improvement to bed_makewindows() issue210

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -21,6 +21,10 @@ intersect_impl <- function(x, y, suffix_x = ".x", suffix_y = ".y") {
     .Call(valr_intersect_impl, x, y, suffix_x, suffix_y)
 }
 
+makewindows_impl <- function(df, step_size = 0L, reverse = FALSE, col_start = "start", col_end = "end", col_win_size = ".win_size") {
+    .Call(valr_makewindows_impl, df, step_size, reverse, col_start, col_end, col_win_size)
+}
+
 merge_impl <- function(gdf, max_dist = 0L, collapse = TRUE) {
     .Call(valr_merge_impl, gdf, max_dist, collapse)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -70,6 +70,22 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// makewindows_impl
+DataFrame makewindows_impl(DataFrame df, int step_size, bool reverse, std::string col_start, std::string col_end, std::string col_win_size);
+RcppExport SEXP valr_makewindows_impl(SEXP dfSEXP, SEXP step_sizeSEXP, SEXP reverseSEXP, SEXP col_startSEXP, SEXP col_endSEXP, SEXP col_win_sizeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
+    Rcpp::traits::input_parameter< int >::type step_size(step_sizeSEXP);
+    Rcpp::traits::input_parameter< bool >::type reverse(reverseSEXP);
+    Rcpp::traits::input_parameter< std::string >::type col_start(col_startSEXP);
+    Rcpp::traits::input_parameter< std::string >::type col_end(col_endSEXP);
+    Rcpp::traits::input_parameter< std::string >::type col_win_size(col_win_sizeSEXP);
+    rcpp_result_gen = Rcpp::wrap(makewindows_impl(df, step_size, reverse, col_start, col_end, col_win_size));
+    return rcpp_result_gen;
+END_RCPP
+}
 // merge_impl
 DataFrame merge_impl(GroupedDataFrame gdf, int max_dist, bool collapse);
 RcppExport SEXP valr_merge_impl(SEXP gdfSEXP, SEXP max_distSEXP, SEXP collapseSEXP) {

--- a/src/init.c
+++ b/src/init.c
@@ -14,6 +14,7 @@ extern SEXP valr_complement_impl(SEXP, SEXP);
 extern SEXP valr_coverage_impl(SEXP, SEXP);
 extern SEXP valr_intersect_impl(SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_merge_impl(SEXP, SEXP, SEXP);
+extern SEXP valr_makewindows_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_random_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_reldist_impl(SEXP, SEXP);
 extern SEXP valr_shuffle_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -26,6 +27,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"valr_coverage_impl",   (DL_FUNC) &valr_coverage_impl,   2},
   {"valr_intersect_impl",  (DL_FUNC) &valr_intersect_impl,  4},
   {"valr_merge_impl",      (DL_FUNC) &valr_merge_impl,      3},
+  {"valr_makewindows_impl",(DL_FUNC) &valr_makewindows_impl,6},
   {"valr_random_impl",     (DL_FUNC) &valr_random_impl,     6},
   {"valr_reldist_impl",    (DL_FUNC) &valr_reldist_impl,    2},
   {"valr_shuffle_impl",    (DL_FUNC) &valr_shuffle_impl,    5},

--- a/src/makewindows.cpp
+++ b/src/makewindows.cpp
@@ -1,0 +1,93 @@
+#include "valr.h"
+
+IntegerVector rcppSeq(int from, int to, int by = 1) {
+  //determine output size
+  std::size_t n = ((to - from) / by) + 1 ;
+  //generate output vector
+  IntegerVector res = Rcpp::rep(from, n) ;
+  // iterate through from to to by step size
+  int idx = 0 ;
+  for (int i = from; i <= to; i += by ){
+    res[idx] = i ;
+    ++idx ;
+  }
+  return res ;
+}
+
+//[[Rcpp::export]]
+DataFrame makewindows_impl(DataFrame df,
+                           int step_size = 0,
+                           bool reverse = false,
+                           std::string col_start = "start",
+                           std::string col_end = "end",
+                           std::string col_win_size = ".win_size") {
+
+  NumericVector starts = df[col_start] ;
+  NumericVector ends = df[col_end] ;
+  NumericVector win_sizes = df[col_win_size] ;
+
+  // all vectors are the same size, take size from starts
+  size_t n = starts.size() ;
+
+  std::vector<int> starts_out ;
+  std::vector<int> ends_out ;
+  std::vector<int> df_idxs ;
+  std::vector<int> window_ids;
+
+  for(int i = 0; i < n ; ++i){
+    auto start = starts[i] ;
+    auto end = ends[i] ;
+    auto win_size = win_sizes[i] ;
+    int by = win_size - step_size ;
+
+    // iterate by step_size
+    auto ivl_starts_out = rcppSeq(start, end, by) ;
+
+    // allocate new ends bases on new starts
+    int out_size = ivl_starts_out.size() ;
+
+    IntegerVector x_idxs = Rcpp::rep(i, out_size) ;
+    IntegerVector ivl_ends_out(out_size) ;
+
+    // make window ids
+    std::vector<int> ids ;
+
+    for(int i = 0; i < out_size ; ++i){
+      // make end equal to end if past end
+      ivl_ends_out[i] = ivl_starts_out[i] + win_size < end ? \
+                        ivl_starts_out[i] + win_size : end ;
+      ids.push_back(i + 1) ;
+    }
+
+    // remove  ivls if start == end
+    for(int i = 0; i < out_size ; ++i){
+      if(ivl_starts_out[i] == ivl_ends_out[i]){
+        x_idxs.erase(x_idxs.begin() + i) ;
+        ids.erase(ids.begin() + i) ;
+        ivl_starts_out.erase(ivl_starts_out.begin() + i) ;
+        ivl_ends_out.erase(ivl_ends_out.begin() + i) ;
+      }
+    }
+    if(reverse){
+      std::reverse(ids.begin(), ids.end());
+    }
+
+    // add new ivls
+    starts_out.insert(starts_out.end(), ivl_starts_out.begin(), ivl_starts_out.end());
+    ends_out.insert(ends_out.end(), ivl_ends_out.begin(), ivl_ends_out.end());
+    df_idxs.insert(df_idxs.end(), x_idxs.begin(), x_idxs.end());
+    window_ids.insert(window_ids.end(), ids.begin(), ids.end());
+  }
+
+  DataFrame out = DataFrameSubsetVisitors(df, names(df)).subset(df_idxs, "data.frame");
+  out[col_start] = starts_out ;
+  out[col_end] = ends_out ;
+  out[".win_id"] = window_ids ;
+
+  return out ;
+}
+
+/*** R
+
+print("temp")
+*/

--- a/src/makewindows.cpp
+++ b/src/makewindows.cpp
@@ -88,6 +88,10 @@ DataFrame makewindows_impl(DataFrame df,
 }
 
 /*** R
+x <- trbl_interval(
+  ~chrom, ~start, ~end, ~name, ~score, ~strand, ~.row_id, ~.win_size,
+  "chr1", 100,    200,  'A',   '.',    '+', 1, 10
+)
 
-print("temp")
+makewindows_impl(x) %>% as_data_frame()
 */


### PR DESCRIPTION
The proposed Cpp implementation is about ~50x faster than the R version. 

The current bed_makewindows() with 1e6 intervals takes ~90 seconds to generate 1e7 intervals.
``` r
library(valr)
library(tidyverse)
#> Loading tidyverse: ggplot2
#> Loading tidyverse: tibble
#> Loading tidyverse: tidyr
#> Loading tidyverse: readr
#> Loading tidyverse: purrr
#> Loading tidyverse: dplyr
#> Conflicts with tidy packages ----------------------------------------------
#> filter(): dplyr, stats
#> lag():    dplyr, stats
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

seed <- 1010486

x <- bed_random(genome, n = 1e6, seed = seed)
res <- bed_makewindows(x, genome, win_size = 100)

x
#> # A tibble: 1,000,000 x 3
#>    chrom     start       end
#>    <chr>     <int>     <int>
#>  1  chr1 141326625 141327625
#>  2  chr1 232877649 232878649
#>  3  chr1 181556041 181557041
#>  4  chr1 127106536 127107536
#>  5  chr1  87669174  87670174
#>  6  chr1 100141515 100142515
#>  7  chr1  28854187  28855187
#>  8  chr1 176996775 176997775
#>  9  chr1  98456315  98457315
#> 10  chr1 111363327 111364327
#> # ... with 999,990 more rows
res
#> # A tibble: 10,000,000 x 4
#>    chrom     start       end .win_id
#>    <chr>     <dbl>     <dbl>   <dbl>
#>  1  chr1 141326625 141326725       1
#>  2  chr1 141326725 141326825       2
#>  3  chr1 141326825 141326925       3
#>  4  chr1 141326925 141327025       4
#>  5  chr1 141327025 141327125       5
#>  6  chr1 141327125 141327225       6
#>  7  chr1 141327225 141327325       7
#>  8  chr1 141327325 141327425       8
#>  9  chr1 141327425 141327525       9
#> 10  chr1 141327525 141327625      10
#> # ... with 9,999,990 more rows
microbenchmark::microbenchmark(res <- bed_makewindows(x, genome, 
                                                      win_size = 100), times = 1, unit = 's')
#> Unit: seconds
#>                                               expr      min       lq
#>  res <- bed_makewindows(x, genome, win_size = 100) 98.82739 98.82739
#>      mean   median       uq      max neval
#>  98.82739 98.82739 98.82739 98.82739     1
```

The Cpp version takes 2 seconds. 
``` r
library(valr)
library(tidyverse)
#> Loading tidyverse: ggplot2
#> Loading tidyverse: tibble
#> Loading tidyverse: tidyr
#> Loading tidyverse: readr
#> Loading tidyverse: purrr
#> Loading tidyverse: dplyr
#> Conflicts with tidy packages ----------------------------------------------
#> filter(): dplyr, stats
#> lag():    dplyr, stats
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

seed <- 1010486

x <- bed_random(genome, n = 1e6, seed = seed)
res <- bed_makewindows(x, genome, win_size = 100)

x
#> # A tibble: 1,000,000 x 3
#>    chrom     start       end
#>    <chr>     <int>     <int>
#>  1  chr1 141326625 141327625
#>  2  chr1 232877649 232878649
#>  3  chr1 181556041 181557041
#>  4  chr1 127106536 127107536
#>  5  chr1  87669174  87670174
#>  6  chr1 100141515 100142515
#>  7  chr1  28854187  28855187
#>  8  chr1 176996775 176997775
#>  9  chr1  98456315  98457315
#> 10  chr1 111363327 111364327
#> # ... with 999,990 more rows
res
#> # A tibble: 10,000,000 x 4
#>    chrom     start       end .win_id
#>    <chr>     <int>     <int>   <int>
#>  1  chr1 141326625 141326725       1
#>  2  chr1 141326725 141326825       2
#>  3  chr1 141326825 141326925       3
#>  4  chr1 141326925 141327025       4
#>  5  chr1 141327025 141327125       5
#>  6  chr1 141327125 141327225       6
#>  7  chr1 141327225 141327325       7
#>  8  chr1 141327325 141327425       8
#>  9  chr1 141327425 141327525       9
#> 10  chr1 141327525 141327625      10
#> # ... with 9,999,990 more rows
microbenchmark::microbenchmark(res <- bed_makewindows(x, genome, 
                                                      win_size = 100), times = 1, unit = 's')
#> Unit: seconds
#>                                               expr     min      lq    mean
#>  res <- bed_makewindows(x, genome, win_size = 100) 2.14319 2.14319 2.14319
#>   median      uq     max neval
#>  2.14319 2.14319 2.14319     1
```

