### PR TITLE
rewrite bed_flank in C++

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,10 @@ absdist_impl <- function(x, y) {
     .Call('valr_absdist_impl', PACKAGE = 'valr', x, y)
 }
 
+flank_impl <- function(inputTable, genome, both = 0, left = 0, right = 0, fraction = FALSE, strand = FALSE, trim = FALSE) {
+    .Call('valr_flank_impl', PACKAGE = 'valr', inputTable, genome, both, left, right, fraction, strand, trim)
+}
+
 closest_impl <- function(x, y, suffix_x, suffix_y) {
     .Call('valr_closest_impl', PACKAGE = 'valr', x, y, suffix_x, suffix_y)
 }

--- a/R/bed_flank.r
+++ b/R/bed_flank.r
@@ -56,6 +56,8 @@ bed_flank <- function(x, genome, both = 0, left = 0,
                       right = 0, fraction = FALSE,
                       strand = FALSE, trim = FALSE, ...) {
 
+  if (!is.tbl_interval(x)) x <- tbl_interval(x)
+
   res <- flank_impl(x, genome, both, left,
                     right, fraction, strand, trim)
 

--- a/R/bed_flank.r
+++ b/R/bed_flank.r
@@ -57,6 +57,7 @@ bed_flank <- function(x, genome, both = 0, left = 0,
                       strand = FALSE, trim = FALSE, ...) {
 
   if (!is.tbl_interval(x)) x <- tbl_interval(x)
+  if (!is.tbl_genome(genome)) genome <- tbl_genome(genome)
 
   res <- flank_impl(x, genome, both, left,
                     right, fraction, strand, trim)

--- a/R/bed_flank.r
+++ b/R/bed_flank.r
@@ -51,101 +51,14 @@
 #' bed_flank(x, genome, both = 0.5, fraction = TRUE)
 #'
 #' @export
+
 bed_flank <- function(x, genome, both = 0, left = 0,
                       right = 0, fraction = FALSE,
                       strand = FALSE, trim = FALSE, ...) {
 
-  if (!is.tbl_interval(x)) x <- tbl_interval(x)
-  if (!is.tbl_genome(genome)) genome <- tbl_genome(genome)
-
-  if (!any(c(both, left, right) > 0))
-    stop('specify one of both, left, right', call. = FALSE)
-
-  if (strand && !'strand' %in% colnames(x))
-    stop('expected `strand` column in `x`', call. = FALSE)
-
-  if (both != 0 && (left != 0 || right != 0))
-    stop('ambiguous side spec for bed_flank', call. = FALSE)
-
-  if (both) left <- right <- both
-
-  if (strand) {
-    if (fraction) {
-      res <- mutate(x, .size = end - start,
-               left_start = ifelse(strand == '+',
-                                start - round( left * .size ),
-                                end),
-               left_end = ifelse(strand == '+',
-                              start,
-                              end + round( left * .size )),
-               right_start = ifelse(strand == '+',
-                                end,
-                                start - round( right * .size )),
-               right_end = ifelse(strand == '+',
-                              end + round( right * .size ),
-                              start))
-
-     res <- select(res, -start, -end, -.size)
-
-    } else {
-      res <- mutate(x, left_start = ifelse(strand == '+',
-                                start - left,
-                                end),
-               left_end = ifelse(strand == '+',
-                              start,
-                              end + left),
-               right_start = ifelse(strand == '+',
-                                end,
-                                start - right),
-               right_end = ifelse(strand == '+',
-                              end + right,
-                              start))
-      res <- select(res, -start, -end)
-    }
-
-  } else {
-    if (fraction) {
-      res <- mutate(x, .size = end - start,
-               left_start =  start - round( left * .size ),
-               left_end = start,
-               right_start = end,
-               right_end = end + round( right * .size ))
-      res <- select(res, -start, -end, -.size)
-
-    } else {
-      res <- mutate(x, left_start = start - left,
-               left_end = start,
-               right_start = end,
-               right_end = end + right)
-      res <- select(res, -start, -end)
-    }
-  }
-
-  if (right && !left) {
-    res <- mutate(res,
-                  start = right_start,
-                  end = right_end)
-    res <- select(res, chrom, start, end, everything(),
-                  -left_start, -left_end, -right_start, -right_end)
-
-  } else if (left && !right) {
-    res <- mutate(res,
-                  start = left_start,
-                  end = left_end)
-    res <- select(res, chrom, start, end, everything(),
-                  -left_start, -left_end, -right_start, -right_end)
-
-  } else {
-    res_left <- select(res, chrom,  left_start,   left_end, everything(), -right_start, -right_end)
-    res_right <- select(res, chrom,  right_start,   right_end, everything(), -left_start, -left_end)
-    res_left <- rename(res_left, start = left_start, end = left_end)
-    res_right<- rename(res_right, start = right_start, end = right_end)
-    res <- bind_rows(res_left, res_right)
-  }
-
-  res <- bound_intervals(res, genome, trim)
-  res <- arrange(res, chrom, start)
-
-  res
+  flank_impl(x, genome, both, left,
+             right, fraction, strand, trim)
 }
+
+
 

--- a/R/bed_flank.r
+++ b/R/bed_flank.r
@@ -56,9 +56,10 @@ bed_flank <- function(x, genome, both = 0, left = 0,
                       right = 0, fraction = FALSE,
                       strand = FALSE, trim = FALSE, ...) {
 
-  flank_impl(x, genome, both, left,
-             right, fraction, strand, trim)
+  res <- flank_impl(x, genome, both, left,
+                    right, fraction, strand, trim)
+
+  arrange(res, chrom, start)
+
 }
-
-
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -18,6 +18,24 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// flank_impl
+DataFrame flank_impl(DataFrame inputTable, DataFrame genome, double both, double left, double right, bool fraction, bool strand, bool trim);
+RcppExport SEXP valr_flank_impl(SEXP inputTableSEXP, SEXP genomeSEXP, SEXP bothSEXP, SEXP leftSEXP, SEXP rightSEXP, SEXP fractionSEXP, SEXP strandSEXP, SEXP trimSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< DataFrame >::type inputTable(inputTableSEXP);
+    Rcpp::traits::input_parameter< DataFrame >::type genome(genomeSEXP);
+    Rcpp::traits::input_parameter< double >::type both(bothSEXP);
+    Rcpp::traits::input_parameter< double >::type left(leftSEXP);
+    Rcpp::traits::input_parameter< double >::type right(rightSEXP);
+    Rcpp::traits::input_parameter< bool >::type fraction(fractionSEXP);
+    Rcpp::traits::input_parameter< bool >::type strand(strandSEXP);
+    Rcpp::traits::input_parameter< bool >::type trim(trimSEXP);
+    rcpp_result_gen = Rcpp::wrap(flank_impl(inputTable, genome, both, left, right, fraction, strand, trim));
+    return rcpp_result_gen;
+END_RCPP
+}
 // closest_impl
 DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y, const std::string& suffix_x, const std::string& suffix_y);
 RcppExport SEXP valr_closest_impl(SEXP xSEXP, SEXP ySEXP, SEXP suffix_xSEXP, SEXP suffix_ySEXP) {

--- a/src/bed_flank.cpp
+++ b/src/bed_flank.cpp
@@ -1,0 +1,181 @@
+// bed_flank.cpp
+//
+// Copyright (C) 2016 - 2017 Jay Hesselberth and Kent Riemondy
+//
+// This file is part of valr.
+//
+// This software may be modified and distributed under the terms
+// of the MIT license. See the LICENSE file for details.
+
+#include "valr.h"
+
+//[[Rcpp::export]]
+DataFrame flank_impl(DataFrame inputTable, DataFrame genome,
+                     double both = 0, double left = 0, double right = 0,
+                     bool fraction = false, bool strand = false, bool trim = false) {
+
+  if (both == 0 & left == 0 & right == 0)
+    stop("specify one of both, left, right");
+
+  if (both != 0 & (left != 0 || right != 0))
+    stop("ambiguous side spec for bed_flank");
+
+  std::vector<std::string> TableNames = inputTable.names();
+  int TableLen = TableNames.size();
+
+  bool strandTest = false;
+
+  for (int i = 0; i < TableLen; i++) {
+    if (TableNames[i] == "strand")
+      strandTest = true;
+  }
+  if (strand == true & strandTest == false)
+    stop("expected strand column");
+
+
+  std::vector<std::string> chroms = inputTable["chrom"];
+  std::vector<int> startCoords = inputTable["start"];
+  std::vector<int> endCoords   = inputTable["end"];
+
+  int N = startCoords.size();
+  std::vector<int> coordSize(N);
+  std::vector<int> idxOut;
+
+  std::vector<double> startOut;
+  std::vector<double> endOut;
+
+  genome_map_t chroMap = makeChromSizes(genome);
+
+  if (both > 0) both = left = right;
+
+  for (int i = 0; i < N; i++) {
+
+    coordSize[i] = endCoords[i] - startCoords[i];
+
+    int leftstart;
+    int leftend;
+    int rightstart;
+    int rightend;
+
+    if (strand == true) {
+      StringVector strands = inputTable["strand"];
+
+      if (fraction == true) {
+        if (strands[i] == "+") {
+          leftstart  = startCoords[i] - coordSize[i] * left;
+          leftend    = startCoords[i];
+          rightstart = endCoords[i];
+          rightend   = endCoords[i] + coordSize[i] * right;
+
+        } else {
+          leftstart  = endCoords[i];
+          leftend    = endCoords[i] + coordSize[i] * left;
+          rightstart = startCoords[i] - coordSize[i] * right;
+          rightend   = startCoords[i];
+        }
+
+      } else {
+
+        if (strands[i] == "+") {
+          leftstart  = startCoords[i] - left;
+          leftend    = startCoords[i];
+          rightstart = endCoords[i];
+          rightend   = endCoords[i] + right;
+
+        } else {
+          leftstart  = endCoords[i];
+          leftend    = endCoords[i] + left;
+          rightstart = startCoords[i] - right;
+          rightend   = startCoords[i];
+        }
+      }
+
+    } else {
+
+      if (fraction == true) {
+        leftstart  = startCoords[i] - coordSize[i] * left;
+        leftend    = startCoords[i];
+        rightstart = endCoords[i];
+        rightend   = endCoords[i] + coordSize[i] * right;
+
+      } else {
+        leftstart  = startCoords[i] - left;
+        leftend    = startCoords[i];
+        rightstart = endCoords[i];
+        rightend   = endCoords[i] + right;
+      }
+    }
+
+    // Compare new intervals to chrom sizes
+    std::string chrom = chroms[i];
+    int chrSize = chroMap[chrom];
+
+    if (left > 0 & leftstart > 0 & leftend <= chrSize) {
+      startOut.push_back (leftstart);
+      endOut.push_back (leftend);
+      idxOut.push_back (i);
+
+    } else if (trim == true & leftstart > 0 & leftend > chrSize) {
+      startOut.push_back (leftstart);
+      endOut.push_back (chrSize);
+      idxOut.push_back (i);
+
+    } else if (trim == true & leftstart <= 0 & leftend <= chrSize) {
+      startOut.push_back (1);
+      endOut.push_back (leftend);
+      idxOut.push_back (i);
+
+    } else if (trim == true & leftstart <= 0 & leftend > chrSize) {
+      startOut.push_back (0);
+      endOut.push_back (chrSize);
+      idxOut.push_back (i);
+    }
+
+
+    if (right > 0 & rightstart > 0 & rightend <= chrSize) {
+      startOut.push_back (rightstart);
+      endOut.push_back (rightend);
+      idxOut.push_back (i);
+
+    } else if (trim == true & rightstart > 0 & rightend > chrSize) {
+      startOut.push_back (rightstart);
+      endOut.push_back (chrSize);
+      idxOut.push_back (i);
+
+    } else if (trim == true & rightstart <= 0 & rightend <= chrSize) {
+      startOut.push_back (1);
+      endOut.push_back (rightend);
+      idxOut.push_back (i);
+
+    } else if (trim == true & rightstart <= 0 & rightend > chrSize) {
+      startOut.push_back (0);
+      endOut.push_back (chrSize);
+      idxOut.push_back (i);
+    }
+  }
+
+  DataFrame outTable = DataFrameSubsetVisitors(inputTable, names(inputTable)).subset(idxOut, "data.frame");
+
+  outTable["start"] = startOut;
+  outTable["end"] = endOut;
+
+  return outTable;
+}
+
+
+
+/*** R
+setwd('~/Downloads/')
+library(valr)
+library(dplyr)
+
+genome <- read_genome('~/Documents/GitHub/valr/inst/extdata/genome.txt.gz')
+x <- bed_random(n = 10000000, genome)
+
+system.time(bed_flank(x, genome, right = 1000, left = 5000, strand = F, trim = T, fraction = T))
+
+y <- bed_flank(x, genome, right = 1000, left = 5000, strand = F, trim = T, fraction = T)
+
+*/
+
+

--- a/src/init.c
+++ b/src/init.c
@@ -24,6 +24,7 @@ extern SEXP valr_absdist_impl(SEXP, SEXP);
 extern SEXP valr_closest_impl(SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_complement_impl(SEXP, SEXP);
 extern SEXP valr_coverage_impl(SEXP, SEXP);
+extern SEXP valr_flank_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_intersect_impl(SEXP, SEXP, SEXP, SEXP);
 extern SEXP valr_merge_impl(SEXP, SEXP);
 extern SEXP valr_random_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -36,6 +37,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"valr_closest_impl",    (DL_FUNC) &valr_closest_impl,    4},
   {"valr_complement_impl", (DL_FUNC) &valr_complement_impl, 2},
   {"valr_coverage_impl",   (DL_FUNC) &valr_coverage_impl,   2},
+  {"valr_flank_impl",      (DL_FUNC) &valr_flank_impl,   8},
   {"valr_intersect_impl",  (DL_FUNC) &valr_intersect_impl,  4},
   {"valr_merge_impl",      (DL_FUNC) &valr_merge_impl,      2},
   {"valr_random_impl",     (DL_FUNC) &valr_random_impl,     6},


### PR DESCRIPTION
I think I have bed_flank working now. This addresses #237. If the final bed_files are not sorted at the end, this speeds up bed_flank by ~7x. The main bottleneck is the final 'arrange'. 