### PR TITLE
Refactor flank

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,7 +17,7 @@ coverage_impl <- function(x, y) {
     .Call(valr_coverage_impl, x, y)
 }
 
-flank_impl <- function(df, genome, both = 0L, left = 0L, right = 0L, fraction = FALSE, stranded = FALSE, trim = FALSE) {
+flank_impl <- function(df, genome, both = 0, left = 0, right = 0, fraction = FALSE, stranded = FALSE, trim = FALSE) {
     .Call(valr_flank_impl, df, genome, both, left, right, fraction, stranded, trim)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,8 +17,8 @@ coverage_impl <- function(x, y) {
     .Call(valr_coverage_impl, x, y)
 }
 
-flank_impl <- function(df, genome, both = 0, left = 0, right = 0, fraction = FALSE, strand = FALSE, trim = FALSE) {
-    .Call(valr_flank_impl, df, genome, both, left, right, fraction, strand, trim)
+flank_impl <- function(df, genome, both = 0L, left = 0L, right = 0L, fraction = FALSE, stranded = FALSE, trim = FALSE) {
+    .Call(valr_flank_impl, df, genome, both, left, right, fraction, stranded, trim)
 }
 
 intersect_impl <- function(x, y, suffix_x = ".x", suffix_y = ".y") {

--- a/R/bed_flank.r
+++ b/R/bed_flank.r
@@ -59,6 +59,17 @@ bed_flank <- function(x, genome, both = 0, left = 0,
   if (!is.tbl_interval(x)) x <- tbl_interval(x)
   if (!is.tbl_genome(genome)) genome <- tbl_genome(genome)
 
+  if (!any(c(both, left, right) > 0))
+    stop('specify one of both, left, right', call. = FALSE)
+
+  if (strand && !'strand' %in% colnames(x))
+    stop('expected `strand` column in `x`', call. = FALSE)
+
+  if (both != 0 && (left != 0 || right != 0))
+    stop('ambiguous side spec for bed_flank', call. = FALSE)
+
+  if (both) left <- right <- both
+
   res <- flank_impl(x, genome, both, left,
                     right, fraction, strand, trim)
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -57,16 +57,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // flank_impl
-DataFrame flank_impl(DataFrame df, DataFrame genome, int both, int left, int right, bool fraction, bool stranded, bool trim);
+DataFrame flank_impl(DataFrame df, DataFrame genome, double both, double left, double right, bool fraction, bool stranded, bool trim);
 RcppExport SEXP valr_flank_impl(SEXP dfSEXP, SEXP genomeSEXP, SEXP bothSEXP, SEXP leftSEXP, SEXP rightSEXP, SEXP fractionSEXP, SEXP strandedSEXP, SEXP trimSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
     Rcpp::traits::input_parameter< DataFrame >::type genome(genomeSEXP);
-    Rcpp::traits::input_parameter< int >::type both(bothSEXP);
-    Rcpp::traits::input_parameter< int >::type left(leftSEXP);
-    Rcpp::traits::input_parameter< int >::type right(rightSEXP);
+    Rcpp::traits::input_parameter< double >::type both(bothSEXP);
+    Rcpp::traits::input_parameter< double >::type left(leftSEXP);
+    Rcpp::traits::input_parameter< double >::type right(rightSEXP);
     Rcpp::traits::input_parameter< bool >::type fraction(fractionSEXP);
     Rcpp::traits::input_parameter< bool >::type stranded(strandedSEXP);
     Rcpp::traits::input_parameter< bool >::type trim(trimSEXP);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -57,20 +57,20 @@ BEGIN_RCPP
 END_RCPP
 }
 // flank_impl
-DataFrame flank_impl(DataFrame df, DataFrame genome, double both, double left, double right, bool fraction, bool strand, bool trim);
-RcppExport SEXP valr_flank_impl(SEXP dfSEXP, SEXP genomeSEXP, SEXP bothSEXP, SEXP leftSEXP, SEXP rightSEXP, SEXP fractionSEXP, SEXP strandSEXP, SEXP trimSEXP) {
+DataFrame flank_impl(DataFrame df, DataFrame genome, int both, int left, int right, bool fraction, bool stranded, bool trim);
+RcppExport SEXP valr_flank_impl(SEXP dfSEXP, SEXP genomeSEXP, SEXP bothSEXP, SEXP leftSEXP, SEXP rightSEXP, SEXP fractionSEXP, SEXP strandedSEXP, SEXP trimSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
     Rcpp::traits::input_parameter< DataFrame >::type genome(genomeSEXP);
-    Rcpp::traits::input_parameter< double >::type both(bothSEXP);
-    Rcpp::traits::input_parameter< double >::type left(leftSEXP);
-    Rcpp::traits::input_parameter< double >::type right(rightSEXP);
+    Rcpp::traits::input_parameter< int >::type both(bothSEXP);
+    Rcpp::traits::input_parameter< int >::type left(leftSEXP);
+    Rcpp::traits::input_parameter< int >::type right(rightSEXP);
     Rcpp::traits::input_parameter< bool >::type fraction(fractionSEXP);
-    Rcpp::traits::input_parameter< bool >::type strand(strandSEXP);
+    Rcpp::traits::input_parameter< bool >::type stranded(strandedSEXP);
     Rcpp::traits::input_parameter< bool >::type trim(trimSEXP);
-    rcpp_result_gen = Rcpp::wrap(flank_impl(df, genome, both, left, right, fraction, strand, trim));
+    rcpp_result_gen = Rcpp::wrap(flank_impl(df, genome, both, left, right, fraction, stranded, trim));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/flank.cpp
+++ b/src/flank.cpp
@@ -15,6 +15,8 @@ void check_coords(int start, int end,
                   std::vector<int>& ends_out,
                   std::vector<int>& df_idx) {
 
+  if (start == end) return ;
+
   if (start > 0 && end <= chrom_size) {
 
     starts_out.push_back(start);
@@ -23,7 +25,7 @@ void check_coords(int start, int end,
 
   } else if (trim) {
 
-    if (start <= 0) {
+    if (start < 1) {
       starts_out.push_back(1) ;
     } else {
       starts_out.push_back(start) ;
@@ -42,7 +44,7 @@ void check_coords(int start, int end,
 
 //[[Rcpp::export]]
 DataFrame flank_impl(DataFrame df, DataFrame genome,
-                     int both = 0, int left = 0, int right = 0,
+                     double both = 0, double left = 0, double right = 0,
                      bool fraction = false, bool stranded = false, bool trim = false) {
 
   std::vector<std::string> chroms = df["chrom"];
@@ -65,7 +67,7 @@ DataFrame flank_impl(DataFrame df, DataFrame genome,
 
       int start = starts[i] ;
       int end = ends[i] ;
-      int size = end - start;
+      double size = end - start;
 
       if (fraction) {
         if (strands[i] == "+") {
@@ -109,7 +111,7 @@ DataFrame flank_impl(DataFrame df, DataFrame genome,
 
       int start = starts[i] ;
       int end = ends[i] ;
-      int size = end - start;
+      double size = end - start;
 
       if (fraction) {
         lstart = start - size * left;


### PR DESCRIPTION
Gives a small additional speedup. Code cleanup.

``` r
library(valr)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(microbenchmark)

genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))
x <- bed_random(genome)

microbenchmark(bed_flank(x, genome, both = 100), times = 1, unit = 's')
#> Unit: seconds
#>                              expr      min       lq     mean   median
#>  bed_flank(x, genome, both = 100) 1.144128 1.144128 1.144128 1.144128
#>        uq      max neval
#>  1.144128 1.144128     1
```