### PR TITLE
OB1 error in bed_flank, issue 277

### DIFF
--- a/src/flank.cpp
+++ b/src/flank.cpp
@@ -17,7 +17,7 @@ void check_coords(int start, int end,
 
   if (start == end) return ;
 
-  if (start > 0 && end <= chrom_size) {
+  if (start >= 0 && end <= chrom_size) {
 
     starts_out.push_back(start);
     ends_out.push_back(end);
@@ -25,8 +25,8 @@ void check_coords(int start, int end,
 
   } else if (trim) {
 
-    if (start < 1) {
-      starts_out.push_back(1) ;
+    if (start < 0) {
+      starts_out.push_back(0) ;
     } else {
       starts_out.push_back(start) ;
     }

--- a/src/flank.cpp
+++ b/src/flank.cpp
@@ -71,14 +71,14 @@ DataFrame flank_impl(DataFrame df, DataFrame genome,
 
       if (fraction) {
         if (strands[i] == "+") {
-          lstart = start - size * left;
+          lstart = start - std::round(size * left);
           lend = start;
           rstart = end;
-          rend = end + size * right;
+          rend = end + std::round(size * right);
         } else {
           lstart = end;
-          lend = end + size * left ;
-          rstart = start - size * right ;
+          lend = end + std::round(size * left) ;
+          rstart = start - std::round(size * right) ;
           rend = start ;
         }
       } else {
@@ -114,10 +114,10 @@ DataFrame flank_impl(DataFrame df, DataFrame genome,
       double size = end - start;
 
       if (fraction) {
-        lstart = start - size * left;
+        lstart = start - std::round(size * left);
         lend = start;
         rstart = end;
-        rend = end + size * right;
+        rend = end + std::round(size * right);
       } else {
         lstart = start - left;
         lend = start;


### PR DESCRIPTION
- clean R CMD Check on rhub https://builder.r-hub.io/status/valr_0.3.0.tar.gz-9fc565a2aead4bf7974e99ebdbe341c0
- the error was an off by one error, only present in 32-bit R. 
- changed reporting from one-based to zero-based
- closes #277
