### PR TITLE
issue312: prevent infinite loop and drop intervals shorter than num_win

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `bed_intersect()` and internal `intersect_impl` were refactored to enable return of non-intersecting intervals.
 
+* The genome argument to `bed_makewindows()` was deprecated and will produce a warning if used. Also error handling was added to check and warn if there are intervals smaller than the requested window size in `makewindows_impl()` (#312 @kriemo)
+
 # valr 0.3.1
 
 ## Enhancements

--- a/R/bed_makewindows.r
+++ b/R/bed_makewindows.r
@@ -41,9 +41,11 @@
 #' dplyr::mutate(wins, namenum = stringr::str_c(name, '_', .win_id))
 #'
 #' @export
-bed_makewindows <- function(x, win_size = 0,
-                            step_size = 0, num_win = 0,
-                            reverse = FALSE, genome = NULL) {
+bed_makewindows <- function(x, genome = NULL,
+                            win_size = 0,
+                            step_size = 0,
+                            num_win = 0,
+                            reverse = FALSE) {
 
   if (!is.null(genome)) {
     warning("genome argument has been deprecated, ignoring",

--- a/R/bed_makewindows.r
+++ b/R/bed_makewindows.r
@@ -1,11 +1,11 @@
 #' Divide intervals into new sub-intervals ("windows").
 #'
 #' @param x [tbl_interval()]
-#' @param genome [tbl_genome()]
 #' @param win_size divide intervals into fixed-size windows
 #' @param step_size size to step before next window
 #' @param num_win divide intervals to fixed number of windows
 #' @param reverse reverse window numbers
+#' @param genome this argument has been deprecated and is not used
 #'
 #' @note The `name` and `.win_id` columns can be used to create new
 #'   interval names (see 'namenum' example below) or in subsequent
@@ -17,40 +17,40 @@
 #'   identifier for the window.
 #'
 #' @examples
-#' genome <- trbl_genome(
-#'  ~chrom, ~size,
-#'  "chr1", 200
-#' )
-#'
 #' x <- trbl_interval(
 #'   ~chrom, ~start, ~end, ~name, ~score, ~strand,
 #'   "chr1", 100,    200,  'A',   '.',    '+'
 #' )
 #'
-#' bed_glyph(bed_makewindows(x, genome, num_win = 10), label = '.win_id')
+#' bed_glyph(bed_makewindows(x, num_win = 10), label = '.win_id')
 #'
 #' # Fixed number of windows
-#' bed_makewindows(x, genome, num_win = 10)
+#' bed_makewindows(x, num_win = 10)
 #'
 #' # Fixed window size
-#' bed_makewindows(x, genome, win_size = 10)
+#' bed_makewindows(x, win_size = 10)
 #'
 #' # Fixed window size with overlaps
-#' bed_makewindows(x, genome, win_size = 10, step_size = 5)
+#' bed_makewindows(x, win_size = 10, step_size = 5)
 #'
 #' # reverse win_id
-#' bed_makewindows(x, genome, win_size = 10, reverse = TRUE)
+#' bed_makewindows(x, win_size = 10, reverse = TRUE)
 #'
 #' # bedtools 'namenum'
-#' wins <- bed_makewindows(x, genome, win_size = 10)
+#' wins <- bed_makewindows(x, win_size = 10)
 #' dplyr::mutate(wins, namenum = stringr::str_c(name, '_', .win_id))
 #'
 #' @export
-bed_makewindows <- function(x, genome, win_size = 0,
+bed_makewindows <- function(x, win_size = 0,
                             step_size = 0, num_win = 0,
-                            reverse = FALSE) {
+                            reverse = FALSE, genome = NULL) {
+
+  if (!is.null(genome)) {
+    warning("genome argument has been deprecated, ignoring",
+            call. = FALSE)
+  }
+
   if (!is.tbl_interval(x)) x <- as.tbl_interval(x)
-  if (!is.tbl_genome(genome)) genome <- as.tbl_genome(genome)
 
   if (win_size == 0 && num_win == 0)
     stop("specify either `win_size` or `num_win`", call. = FALSE)

--- a/R/bed_makewindows.r
+++ b/R/bed_makewindows.r
@@ -41,15 +41,23 @@
 #' dplyr::mutate(wins, namenum = stringr::str_c(name, '_', .win_id))
 #'
 #' @export
-bed_makewindows <- function(x, genome = NULL,
+bed_makewindows <- function(x,
+                            genome = NULL,
                             win_size = 0,
                             step_size = 0,
                             num_win = 0,
                             reverse = FALSE) {
 
+  # handle deprecated genome argument
   if (!is.null(genome)) {
-    warning("genome argument has been deprecated, ignoring",
-            call. = FALSE)
+    if (is.list(genome)) {
+      warning("genome argument has been deprecated, ignoring",
+              call. = FALSE)
+    } else if (is.numeric(genome)) {
+        # if win_size is passed as positional argument it will be genome
+        # reassign to win_size
+        win_size <- genome
+    }
   }
 
   if (!is.tbl_interval(x)) x <- as.tbl_interval(x)

--- a/man/bed_makewindows.Rd
+++ b/man/bed_makewindows.Rd
@@ -4,11 +4,13 @@
 \alias{bed_makewindows}
 \title{Divide intervals into new sub-intervals ("windows").}
 \usage{
-bed_makewindows(x, win_size = 0, step_size = 0, num_win = 0,
-  reverse = FALSE, genome = NULL)
+bed_makewindows(x, genome = NULL, win_size = 0, step_size = 0,
+  num_win = 0, reverse = FALSE)
 }
 \arguments{
 \item{x}{\code{\link[=tbl_interval]{tbl_interval()}}}
+
+\item{genome}{this argument has been deprecated and is not used}
 
 \item{win_size}{divide intervals into fixed-size windows}
 
@@ -17,8 +19,6 @@ bed_makewindows(x, win_size = 0, step_size = 0, num_win = 0,
 \item{num_win}{divide intervals to fixed number of windows}
 
 \item{reverse}{reverse window numbers}
-
-\item{genome}{this argument has been deprecated and is unused}
 }
 \value{
 \code{\link[=tbl_interval]{tbl_interval()}} with \code{.win_id} column that contains a numeric

--- a/man/bed_makewindows.Rd
+++ b/man/bed_makewindows.Rd
@@ -4,13 +4,11 @@
 \alias{bed_makewindows}
 \title{Divide intervals into new sub-intervals ("windows").}
 \usage{
-bed_makewindows(x, genome, win_size = 0, step_size = 0, num_win = 0,
-  reverse = FALSE)
+bed_makewindows(x, win_size = 0, step_size = 0, num_win = 0,
+  reverse = FALSE, genome = NULL)
 }
 \arguments{
 \item{x}{\code{\link[=tbl_interval]{tbl_interval()}}}
-
-\item{genome}{\code{\link[=tbl_genome]{tbl_genome()}}}
 
 \item{win_size}{divide intervals into fixed-size windows}
 
@@ -19,6 +17,8 @@ bed_makewindows(x, genome, win_size = 0, step_size = 0, num_win = 0,
 \item{num_win}{divide intervals to fixed number of windows}
 
 \item{reverse}{reverse window numbers}
+
+\item{genome}{this argument has been deprecated and is unused}
 }
 \value{
 \code{\link[=tbl_interval]{tbl_interval()}} with \code{.win_id} column that contains a numeric
@@ -33,32 +33,27 @@ interval names (see 'namenum' example below) or in subsequent
 \code{group_by} operations (see vignette).
 }
 \examples{
-genome <- trbl_genome(
- ~chrom, ~size,
- "chr1", 200
-)
-
 x <- trbl_interval(
   ~chrom, ~start, ~end, ~name, ~score, ~strand,
   "chr1", 100,    200,  'A',   '.',    '+'
 )
 
-bed_glyph(bed_makewindows(x, genome, num_win = 10), label = '.win_id')
+bed_glyph(bed_makewindows(x, num_win = 10), label = '.win_id')
 
 # Fixed number of windows
-bed_makewindows(x, genome, num_win = 10)
+bed_makewindows(x, num_win = 10)
 
 # Fixed window size
-bed_makewindows(x, genome, win_size = 10)
+bed_makewindows(x, win_size = 10)
 
 # Fixed window size with overlaps
-bed_makewindows(x, genome, win_size = 10, step_size = 5)
+bed_makewindows(x, win_size = 10, step_size = 5)
 
 # reverse win_id
-bed_makewindows(x, genome, win_size = 10, reverse = TRUE)
+bed_makewindows(x, win_size = 10, reverse = TRUE)
 
 # bedtools 'namenum'
-wins <- bed_makewindows(x, genome, win_size = 10)
+wins <- bed_makewindows(x, win_size = 10)
 dplyr::mutate(wins, namenum = stringr::str_c(name, '_', .win_id))
 
 }

--- a/src/makewindows.cpp
+++ b/src/makewindows.cpp
@@ -31,10 +31,10 @@ DataFrame makewindows_impl(DataFrame df, int win_size = 0, int num_win = 0,
       if (ivl_len < num_win) {
         CharacterVector chroms = df["chrom"] ;
         auto chrom = as<std::string>(chroms[i]) ;
-        warning("WARNING: Interval %s:%d-%d, "
+        warning("Interval %s:%d-%d, "
                 "smaller than requested number "
                 "of windows. skipping",
-                chroms, start, end);
+                chrom, start, end);
         continue ;
       }
       win_size = round((ivl_len) / num_win) ;

--- a/src/makewindows.cpp
+++ b/src/makewindows.cpp
@@ -27,7 +27,17 @@ DataFrame makewindows_impl(DataFrame df, int win_size = 0, int num_win = 0,
     auto end = ends[i] ;
 
     if (num_win > 0) {
-      win_size = round((end - start) / num_win) ;
+      int ivl_len = end - start ;
+      if (ivl_len < num_win) {
+        CharacterVector chroms = df["chrom"] ;
+        auto chrom = as<std::string>(chroms[i]) ;
+        warning("WARNING: Interval %s:%d-%d, "
+                "smaller than requested number "
+                "of windows. skipping",
+                chroms, start, end);
+        continue ;
+      }
+      win_size = round((ivl_len) / num_win) ;
     }
 
     int by = win_size - step_size ;
@@ -79,11 +89,6 @@ x <- trbl_interval(
   "chr1", 100,    200
 )
 
-genome <- trbl_genome(
-  ~chrom, ~size,
-  "chr1", 500
-)
-
-bed_makewindows(x, genome, win_size = 10)
-bed_makewindows(x, genome, win_size = 10, reverse = TRUE)
+bed_makewindows(x, win_size = 10)
+bed_makewindows(x, win_size = 10, reverse = TRUE)
 */

--- a/tests/testthat/test_makewindows.r
+++ b/tests/testthat/test_makewindows.r
@@ -85,7 +85,7 @@ test_that("num_win rev", {
 test_that("interval is smaller than n windows", {
   # test warning
   expect_warning(bed_makewindows(x, num_win = 150),
-                 "WARNING: Interval ")
+                 "Interval [^:]+:\\d+-\\d+, smaller than requested number of windows. skipping")
   # test that intervals are dropped if num_win > than interval size
   res <- suppressWarnings(bed_makewindows(x, num_win = 150))
   expect_equal(nrow(res), 0)

--- a/tests/testthat/test_makewindows.r
+++ b/tests/testthat/test_makewindows.r
@@ -1,11 +1,5 @@
 context("bed_makewindows")
 
-genome <- tibble::tribble(
-  ~chrom, ~size,
-  "chr1", 5000,
-  "chr2", 400
-)
-
 x <- tibble::tribble(
   ~chrom, ~start, ~end, ~name,
   "chr1", 100, 200, "A",
@@ -14,13 +8,13 @@ x <- tibble::tribble(
 
 # Window IDs are generated
 test_that("window IDs are generated", {
-  res <- bed_makewindows(x, genome, win_size = 10)
+  res <- bed_makewindows(x, win_size = 10)
   expect_true(".win_id" %in% colnames(res))
 })
 
 # Fixed win_size with foward numbering
 test_that("win_size fwd", {
-  res <- bed_makewindows(x, genome, win_size = 10)
+  res <- bed_makewindows(x, win_size = 10)
   # test number of windows
   expect_equal(nrow(res), 15)
   # test forward window numbering
@@ -31,7 +25,7 @@ test_that("win_size fwd", {
 
 # Fixed win_size with reverse numbering
 test_that("win_size rev", {
-  res <- bed_makewindows(x, genome, reverse = TRUE, win_size = 10)
+  res <- bed_makewindows(x, reverse = TRUE, win_size = 10)
   # test number of windows
   expect_equal(nrow(res), 15)
   # test forward window numbering
@@ -42,7 +36,7 @@ test_that("win_size rev", {
 
 # Fixed win_size +step_size with forward numbering
 test_that("win_size +step_size fwd", {
-  res <- bed_makewindows(x, genome, win_size = 10, step_size = 5)
+  res <- bed_makewindows(x, win_size = 10, step_size = 5)
   # test number of windows
   expect_equal(nrow(res), 30)
   # test forward window numbering
@@ -54,7 +48,7 @@ test_that("win_size +step_size fwd", {
 
 # Fixed win_size +step_size with reverse numbering
 test_that("win_size +step_size rev", {
-  res <- bed_makewindows(x, genome, reverse = TRUE, win_size = 10, step_size = 5)
+  res <- bed_makewindows(x, reverse = TRUE, win_size = 10, step_size = 5)
   # test number of windows
   expect_equal(nrow(res), 30)
   # test forward window numbering
@@ -66,7 +60,7 @@ test_that("win_size +step_size rev", {
 
 # Fixed number of windows with forward numbering
 test_that("num_win fwd", {
-  res <- bed_makewindows(x, genome, num_win = 10)
+  res <- bed_makewindows(x, num_win = 10)
   # test number of windows
   expect_equal(nrow(res), 20)
   # test forward window numbering
@@ -78,7 +72,7 @@ test_that("num_win fwd", {
 
 # Fixed number of windows with reverse numbering
 test_that("num_win rev", {
-  res <- bed_makewindows(x, genome, reverse = TRUE, num_win = 10)
+  res <- bed_makewindows(x, reverse = TRUE, num_win = 10)
   # test number of windows
   expect_equal(nrow(res), 20)
   # test forward window numbering
@@ -86,4 +80,13 @@ test_that("num_win rev", {
   # test interval size
   expect_true(all(res[1:10, "end"] - res[1:10, "start"] == 10))
   expect_true(all(res[11:20, "end"] - res[11:20, "start"] == 5))
+})
+
+test_that("interval is smaller than n windows", {
+  # test warning
+  expect_warning(bed_makewindows(x, num_win = 150),
+                 "WARNING: Interval ")
+  # test that intervals are dropped if num_win > than interval size
+  res <- suppressWarnings(bed_makewindows(x, num_win = 150))
+  expect_equal(nrow(res), 0)
 })

--- a/vignettes/benchmarks.Rmd
+++ b/vignettes/benchmarks.Rmd
@@ -66,7 +66,7 @@ res <- microbenchmark(
   bed_fisher(x, y, genome),
   bed_projection(x, y, genome),
   # utilities
-  bed_makewindows(x, genome, win_size = 100),
+  bed_makewindows(x, win_size = 100),
   times = nrep,
   unit = 's')
 

--- a/vignettes/valr.Rmd
+++ b/vignettes/valr.Rmd
@@ -248,7 +248,7 @@ win_size <- 50
 # add slop to the TSS, break into windows and add a group
 x <- tss %>%
   bed_slop(genome, both = region_size) %>%
-  bed_makewindows(genome, win_size)
+  bed_makewindows(win_size)
 
 x
 ```


### PR DESCRIPTION
add warnings to make_windows
  - warn and skip interval if num_win is greater than interval size
  - deprecate genome argument to bed
  - add test for warning and skipped intervals
  - remove genome argument from examples and vignettes
  - closes #312 
