### PR TITLE
use group_vars to avoid mixing character and symbol vectors.

### DIFF
--- a/R/bed_map.r
+++ b/R/bed_map.r
@@ -82,7 +82,7 @@ bed_map <- function(x, y, ..., invert = FALSE,
   if (!is.tbl_interval(x)) x <- as.tbl_interval(x)
   if (!is.tbl_interval(y)) y <- as.tbl_interval(y)
 
-  groups_x <- groups(x)
+  groups_x <- group_vars(x)
 
   # used only to get the `x` suffix; `y` suffix is ignored`
   suffix <- list(x = suffix[1], y = suffix[2])

--- a/R/bed_merge.r
+++ b/R/bed_merge.r
@@ -56,7 +56,7 @@ bed_merge <- function(x, max_dist = 0, ...) {
 
   if (is_merged(x)) return(x)
 
-  groups_x <- groups(x)
+  groups_x <- group_vars(x)
 
   res <- bed_sort(x)
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -81,8 +81,8 @@ reorder_names <- function(x, y) {
 #' shared_groups(x, y)
 #' @noRd
 shared_groups <- function(x, y) {
-  groups_x <- groups(x)
-  groups_y <- groups(y)
+  groups_x <- group_vars(x)
+  groups_y <- group_vars(y)
 
   groups_xy <- intersect(groups_x, groups_y)
   if (length(groups_xy) == 0) {


### PR DESCRIPTION
Fixes an issue with rlang devel.