### PR TITLE
bed_makewindows: require that the same number of requested intervals are always returned

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+* `bed_makewindows()` now returns the number of windows specified by `num_win` when the input intervals are not evenly divisble into `num_win`, consistent with `bedtools` behavior.
+
 * The output of `findOverlaps()` is now sorted in `subtract_impl()` to prevent reporting intervals that should have been dropped when calling `bed_subtract()` (#316 @kriemo)
 
 ## Minor changes

--- a/R/bed_makewindows.r
+++ b/R/bed_makewindows.r
@@ -65,6 +65,9 @@ bed_makewindows <- function(x,
   if (win_size == 0 && num_win == 0)
     stop("specify either `win_size` or `num_win`", call. = FALSE)
 
+  if (win_size < 0 || num_win < 0)
+    stop("`win_size` or `num_win` must be positive values", call. = FALSE)
+
   # dummy win_ids
   x <- mutate(x, .win_id = 0)
   res <- makewindows_impl(x, win_size, num_win, step_size, reverse)

--- a/src/makewindows.cpp
+++ b/src/makewindows.cpp
@@ -47,6 +47,10 @@ DataFrame makewindows_impl(DataFrame df, int win_size = 0, int num_win = 0,
     for (int j = start; j < end && j + win_size - by <= end; j += by) {
       starts_by.push_back(j) ;
     }
+    // drop extra window added due to non-integer win_size
+    if (num_win > 0 & starts_by.size() > num_win) {
+      starts_by.pop_back() ;
+    }
 
     int nstarts = starts_by.size() ;
     for (int k = 0; k < nstarts; ++k) {
@@ -54,7 +58,8 @@ DataFrame makewindows_impl(DataFrame df, int win_size = 0, int num_win = 0,
       auto start_by = starts_by[k] ;
       starts_out.push_back(start_by) ;
 
-      if (start_by + win_size < end) {
+      // for last iteration through starts also extend to end
+      if (start_by + win_size < end & k < nstarts - 1) {
         ends_out.push_back(start_by + win_size) ;
       } else {
         ends_out.push_back(end) ;

--- a/src/makewindows.cpp
+++ b/src/makewindows.cpp
@@ -59,7 +59,7 @@ DataFrame makewindows_impl(DataFrame df, int win_size = 0, int num_win = 0,
       starts_out.push_back(start_by) ;
 
       // for last iteration through starts also extend to end
-      if (start_by + win_size < end & k < nstarts - 1) {
+      if (start_by + win_size < end && k < nstarts - 1) {
         ends_out.push_back(start_by + win_size) ;
       } else {
         ends_out.push_back(end) ;

--- a/tests/testthat/test_makewindows.r
+++ b/tests/testthat/test_makewindows.r
@@ -101,3 +101,8 @@ test_that("always get the number of requested windows. issue #322", {
   expect_equal(res$start[10], 38)
   expect_equal(res$end[10], 44)
 })
+
+test_that("report error if negative value win_size or num_win arguments supplied", {
+  expect_error(bed_makewindows(x, num_win = -1))
+  expect_error(bed_makewindows(x, win_size = -1))
+})

--- a/tests/testthat/test_makewindows.r
+++ b/tests/testthat/test_makewindows.r
@@ -90,3 +90,14 @@ test_that("interval is smaller than n windows", {
   res <- suppressWarnings(bed_makewindows(x, num_win = 150))
   expect_equal(nrow(res), 0)
 })
+
+test_that("always get the number of requested windows. issue #322", {
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end, ~name,
+    "chr1", 11, 44, "A"
+  )
+  res <- bed_makewindows(x, num_win = 10)
+  expect_equal(nrow(res), 10)
+  expect_equal(res$start[10], 38)
+  expect_equal(res$end[10], 44)
+})


### PR DESCRIPTION
minor changes to `makewindows_impl` to conform with bedtools reporting 
- closes issue #322