### PR TITLE
bed_glyph: allow x and y arguments to named other than x and y

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+* `bed_glyph()` accepts `trbl_intervals` named other than `x` and `y` (#318)
+
 * `bed_makewindows()` now returns the number of windows specified by `num_win` when the input intervals are not evenly divisble into `num_win`, consistent with `bedtools` behavior.
 
 * The output of `findOverlaps()` is now sorted in `subtract_impl()` to prevent reporting intervals that should have been dropped when calling `bed_subtract()` (#316 @kriemo)

--- a/R/bed_glyph.r
+++ b/R/bed_glyph.r
@@ -100,7 +100,7 @@ bed_glyph <- function(expr, label = NULL) {
 
   # this fetches the `x` and `y` rows from the environment
   for (i in 1:nargs) {
-    env_i <- get(args_req[i], env)
+    env_i <- get(expr_vars[i], env)
     rows <- mutate(env_i, .facet = expr_vars[i])
     res <- bind_rows(res, rows)
   }

--- a/tests/testthat/test_glyph.r
+++ b/tests/testthat/test_glyph.r
@@ -29,8 +29,7 @@ b <- trbl_interval(
 
 test_that("expr arguments do not need to be x and/or y", {
   res <- bed_glyph(bed_intersect(a, b))
-  res_class <- class(res)
-  expect_true("ggplot" %in% res_class)
+  expect_is(res, "ggplot")
 })
 
 genome <- tibble::tribble(

--- a/tests/testthat/test_glyph.r
+++ b/tests/testthat/test_glyph.r
@@ -16,6 +16,23 @@ test_that("glyph labels are applied", {
   expect_equal(res$labels$label, "id")
 })
 
+a <- trbl_interval(
+  ~chrom, ~start, ~end,
+  'chr1', 25,     50,
+  'chr1', 100,    125
+)
+
+b <- trbl_interval(
+  ~chrom, ~start, ~end, ~value,
+  'chr1', 30,     75,  50
+)
+
+test_that("expr arguments do not need to be x and/or y", {
+  res <- bed_glyph(bed_intersect(a, b))
+  res_class <- class(res)
+  expect_true("ggplot" %in% res_class)
+})
+
 genome <- tibble::tribble(
   ~chrom, ~size,
   "chr1", 1e6


### PR DESCRIPTION

``` r
library(valr)

a <- trbl_interval(
  ~chrom, ~start, ~end,
  'chr1', 25,     50,
  'chr1', 100,    125
)

b <- trbl_interval(
  ~chrom, ~start, ~end, ~value,
  'chr1', 30,     75,  50
)

bed_glyph(bed_intersect(a, b))
```

![](https://i.imgur.com/nHG1Phn.png)

``` r

bed_glyph(bed_intersect(x = a, y = b))
```

![](https://i.imgur.com/HSD4J7Z.png)

Created on 2018-01-24 by the [reprex package](http://reprex.tidyverse.org) (v0.1.1.9000).