### PR TITLE
closest behavior on book-ended intervals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## Bug fixes
 
-* `bed_glyph()` accepts `trbl_intervals` named other than `x` and `y` (#318)
+* Fixed off by one error in reported distances from `bed_closest()`. Distances reported now are the same as `bedtools closest` behavior (#311).
+
+* `bed_glyph()` accepts `trbl_intervals` named other than `x` and `y` (#318).
 
 * `bed_makewindows()` now returns the number of windows specified by `num_win` when the input intervals are not evenly divisble into `num_win`, consistent with `bedtools` behavior.
 

--- a/src/closest.cpp
+++ b/src/closest.cpp
@@ -35,16 +35,16 @@ void closest_grouped(ivl_vector_t& vx, ivl_vector_t& vy,
         indices_y.push_back(ov_it.value) ;
         overlap_sizes.push_back(overlap < 0 ? -overlap : overlap) ;
         distance_sizes.push_back(0);
-      } else if (ov_it.start > vx_it.stop) {
+      } else if (ov_it.start >= vx_it.stop) {
         indices_x.push_back(vx_it.value) ;
         indices_y.push_back(ov_it.value) ;
         overlap_sizes.push_back(0) ;
-        distance_sizes.push_back(-overlap);
+        distance_sizes.push_back(-(overlap - 1));
       } else {
         indices_x.push_back(vx_it.value) ;
         indices_y.push_back(ov_it.value) ;
         overlap_sizes.push_back(0) ;
-        distance_sizes.push_back(overlap);
+        distance_sizes.push_back(overlap - 1);
       }
 
     }

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -16,6 +16,9 @@ test_that("1bp closer, check for off-by-one errors", {
   )
   res <- bed_closest(x, y)
   expect_equal(nrow(res), 3)
+  expect_true(res[1, ]$.dist == -1)
+  expect_true(res[2, ]$.dist == 0)
+  expect_true(res[3, ]$.dist == 1)
 })
 
 test_that("reciprocal test of 1bp closer, check for off-by-one errors", {
@@ -32,6 +35,9 @@ test_that("reciprocal test of 1bp closer, check for off-by-one errors", {
   )
   res <- bed_closest(y, x)
   expect_equal(nrow(res), 3)
+  expect_true(res[1, ]$.dist == 1)
+  expect_true(res[2, ]$.dist == 0)
+  expect_true(res[3, ]$.dist == -1)
 })
 
 test_that("0bp apart closer, check for off-by-one errors", {
@@ -48,6 +54,9 @@ test_that("0bp apart closer, check for off-by-one errors", {
   )
   res <- bed_closest(x, y)
   expect_equal(nrow(res), 3)
+  expect_true(res[1, ]$.dist == -1)
+  expect_true(res[2, ]$.dist == 0)
+  expect_true(res[3, ]$.dist == 1)
 })
 
 test_that("reciprocal of 0bp apart closer, check for off-by-one errors", {
@@ -64,6 +73,9 @@ test_that("reciprocal of 0bp apart closer, check for off-by-one errors", {
   )
   res <- bed_closest(y, x)
   expect_equal(nrow(res), 3)
+  expect_true(res[1, ]$.dist == 1)
+  expect_true(res[2, ]$.dist == 0)
+  expect_true(res[3, ]$.dist == -1)
 })
 
 test_that("check that first left interval at index 0 is not lost", {
@@ -122,7 +134,7 @@ test_that("check that same strand is reported (strand = TRUE", {
 
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
-    "chr1", 80, 100, "q1", 1, "+", 5, 15, "d1.1", 1, "+", 0, -65
+    "chr1", 80, 100, "q1", 1, "+", 5, 15, "d1.1", 1, "+", 0, -66
   )
 
   res <- bed_closest(group_by(x, strand), group_by(y, strand))
@@ -144,7 +156,7 @@ test_that("check that different strand is reported (strand_opp = TRUE", {
 
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "q1", 1, "+", 20, 60, "d1.2", 2, "+", 0, -20
+    "chr1", 80, 100, "q1", 1, "+", 20, 60, "d1.2", 2, "+", 0, -21
   )
 
   res <- bed_closest(group_by(x, strand), group_by(flip_strands(y), strand))
@@ -242,11 +254,11 @@ test_that("test reporting of first overlapping feature and
   )
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~start.y, ~end.y, ~.dist,
-    "chr1", 100, 101, 150, 201, 49,
-    "chr1", 200, 201, 100, 101, -99,
-    "chr1", 300, 301, 150, 201, -99,
-    "chr1", 100000, 100010, 175, 375, -99625,
-    "chr1", 100020, 100040, 175, 375, -99645
+    "chr1", 100, 101, 150, 201, 50,
+    "chr1", 200, 201, 100, 101, -100,
+    "chr1", 300, 301, 150, 201, -100,
+    "chr1", 100000, 100010, 175, 375, -99626,
+    "chr1", 100020, 100040, 175, 375, -99646
   )
   res <- bed_closest(x, y, overlap = F)
   expect_true(all(pred == res))
@@ -288,7 +300,7 @@ d_d2R <- tibble::tribble(
 test_that("default distance reporting works for forward hit on left, forward query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q1.1", 5, "+", 40, 60, "d1F.1", 10, "+", 0, -20
+    "chr1", 80, 100, "d_q1.1", 5, "+", 40, 60, "d1F.1", 10, "+", 0, -21
   )
   res <- bed_closest(d_q1, d_d1F)
   expect_true(all(pred == res))
@@ -297,7 +309,7 @@ test_that("default distance reporting works for forward hit on left, forward que
 test_that("default distance reporting works for reverse hit on left, forward query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q1.1", 5, "+", 40, 60, "d1R.1", 10, "-", 0, -20
+    "chr1", 80, 100, "d_q1.1", 5, "+", 40, 60, "d1R.1", 10, "-", 0, -21
   )
   res <- bed_closest(d_q1, d_d1R)
   expect_true(all(pred == res))
@@ -306,7 +318,7 @@ test_that("default distance reporting works for reverse hit on left, forward que
 test_that("default distance reporting works for forward hit on left, reverse query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q2.1", 5, "-", 40, 60, "d1F.1", 10, "+", 0, -20
+    "chr1", 80, 100, "d_q2.1", 5, "-", 40, 60, "d1F.1", 10, "+", 0, -21
   )
   res <- bed_closest(d_q2, d_d1F)
   expect_true(all(pred == res))
@@ -315,7 +327,7 @@ test_that("default distance reporting works for forward hit on left, reverse que
 test_that("default distance reporting works for reverse hit on left, reverse query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q2.1", 5, "-", 40, 60, "d1R.1", 10, "-", 0, -20
+    "chr1", 80, 100, "d_q2.1", 5, "-", 40, 60, "d1R.1", 10, "-", 0, -21
   )
   res <- bed_closest(d_q2, d_d1R)
   expect_true(all(pred == res))
@@ -324,7 +336,7 @@ test_that("default distance reporting works for reverse hit on left, reverse que
 test_that("default distance reporting works for forward hit on right, forward query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q1.1", 5, "+", 140, 160, "d2F.1", 10, "+", 0, 40
+    "chr1", 80, 100, "d_q1.1", 5, "+", 140, 160, "d2F.1", 10, "+", 0, 41
   )
   res <- bed_closest(d_q1, d_d2F)
   expect_true(all(pred == res))
@@ -333,7 +345,7 @@ test_that("default distance reporting works for forward hit on right, forward qu
 test_that("default distance reporting works for reverse hit on right, forward query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q1.1", 5, "+", 140, 160, "d2R.1", 10, "-", 0, 40
+    "chr1", 80, 100, "d_q1.1", 5, "+", 140, 160, "d2R.1", 10, "-", 0, 41
   )
   res <- bed_closest(d_q1, d_d2R)
   expect_true(all(pred == res))
@@ -342,7 +354,7 @@ test_that("default distance reporting works for reverse hit on right, forward qu
 test_that("default distance reporting works for forward hit on right, reverse query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q2.1", 5, "-", 140, 160, "d2F.1", 10, "+", 0, 40
+    "chr1", 80, 100, "d_q2.1", 5, "-", 140, 160, "d2F.1", 10, "+", 0, 41
   )
   res <- bed_closest(d_q2, d_d2F)
   expect_true(all(pred == res))
@@ -351,7 +363,7 @@ test_that("default distance reporting works for forward hit on right, reverse qu
 test_that("default distance reporting works for reverse hit on right, reverse query", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 80, 100, "d_q2.1", 5, "-", 140, 160, "d2R.1", 10, "-", 0, 40
+    "chr1", 80, 100, "d_q2.1", 5, "-", 140, 160, "d2R.1", 10, "-", 0, 41
   )
   res <- bed_closest(d_q2, d_d2R)
   expect_true(all(pred == res))
@@ -372,8 +384,8 @@ b2 <- tibble::tribble(
 test_that("Make sure non-overlapping ties are reported ", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 10, 20, "a1", 1, "-", 8, 9, "b1", 1, "+", 0, -1,
-    "chr1", 10, 20, "a1", 1, "-", 21, 22, "b2", 1, "-", 0, 1
+    "chr1", 10, 20, "a1", 1, "-", 8, 9, "b1", 1, "+", 0, -2,
+    "chr1", 10, 20, "a1", 1, "-", 21, 22, "b2", 1, "-", 0, 2
   )
   res <- bed_closest(a2, b2)
   expect_true(all(pred == res))
@@ -382,7 +394,7 @@ test_that("Make sure non-overlapping ties are reported ", {
 test_that("Make sure non-overlapping ties are reported with strand = T ", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 10, 20, "a1", 1, "-", 21, 22, "b2", 1, "-", 0, 1
+    "chr1", 10, 20, "a1", 1, "-", 21, 22, "b2", 1, "-", 0, 2
   )
   res <- bed_closest(group_by(a2, strand), group_by(b2, strand))
   expect_true(all(pred == res))
@@ -391,7 +403,7 @@ test_that("Make sure non-overlapping ties are reported with strand = T ", {
 test_that("Make sure non-overlapping ties are reported with strand_opp = T ", {
   pred <- tibble::tribble(
     ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.dist,
-    "chr1", 10, 20, "a1", 1, "-", 8, 9, "b1", 1, "-", 0, -1
+    "chr1", 10, 20, "a1", 1, "-", 8, 9, "b1", 1, "-", 0, -2
   )
   res <- bed_closest(group_by(a2, strand), group_by(flip_strands(b2), strand))
   expect_true(all(pred == res))


### PR DESCRIPTION
Distances are now reported correctly for book-ended intervals. The tests have been updated to reflect this fix. The distances reported are now also the same as bedtools closest output. 

closes #311 

``` r
library(valr)

x <- trbl_interval(
  ~chrom, ~start, ~end,
  "chr1", 100,    150
)

y <- trbl_interval(
  ~chrom, ~start, ~end,
  "chr1", 99,     100,
  "chr1", 100,    101,
  "chr1", 150,    151
)

bed_closest(x, y)
#> # A tibble: 3 x 7
#>   chrom start.x end.x start.y end.y .overlap .dist
#>   <chr>   <dbl> <dbl>   <dbl> <dbl>    <int> <int>
#> 1  chr1     100   150      99   100        0    -1
#> 2  chr1     100   150     100   101        1     0
#> 3  chr1     100   150     150   151        0     1
```

Created on 2018-01-24 by the [reprex package](http://reprex.tidyverse.org) (v0.1.1.9000).