### PR TITLE
Additional fix for too many windows reported by makewindows

### DIFF
--- a/src/makewindows.cpp
+++ b/src/makewindows.cpp
@@ -44,12 +44,15 @@ DataFrame makewindows_impl(DataFrame df, int win_size = 0, int num_win = 0,
 
     // create candidate starts
     std::vector<int> starts_by ;
-    for (int j = start; j < end && j + win_size - by <= end; j += by) {
-      starts_by.push_back(j) ;
-    }
-    // drop extra window added due to non-integer win_size
-    if (num_win > 0 & starts_by.size() > num_win) {
-      starts_by.pop_back() ;
+    if (num_win > 0){
+      int win_idx = 0 ;
+      for (int j = start; j < end && win_idx < num_win; j += win_size, ++win_idx) {
+        starts_by.push_back(j) ;
+        }
+    } else {
+      for (int j = start; j < end && j + win_size - by <= end; j += by) {
+        starts_by.push_back(j) ;
+        }
     }
 
     int nstarts = starts_by.size() ;

--- a/tests/testthat/test_makewindows.r
+++ b/tests/testthat/test_makewindows.r
@@ -106,3 +106,14 @@ test_that("report error if negative value win_size or num_win arguments supplied
   expect_error(bed_makewindows(x, num_win = -1))
   expect_error(bed_makewindows(x, win_size = -1))
 })
+
+test_that("check num_win reported correctly for additional intervals (related to #322)", {
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    "chr1", 9437053, 9438070,
+    "chr1", 75360291, 75368579,
+    "chr1", 86351980, 86352127
+  )
+  res <- bed_makewindows(x, num_win = 100)
+  expect_equal(max(res$.win_id), 100)
+})


### PR DESCRIPTION
PR #325 didn't fully resolve the issue of requiring that the number of windows returned is equal to the `num_win` argument. This PR adds explicit iteration logic to handle the `num_win` argument and an additional test. 

Here's a set of intervals that lead to excess windows reported with current implementation. 
``` r
library(valr)
library(dplyr)

x <- tibble::tribble(
  ~chrom, ~start, ~end,
  "chr1", 9437053, 9438070,
  "chr1", 75360291, 75368579,
  "chr1", 86351980, 86352127
)

res <- bed_makewindows(x, num_win = 100)

res
#> # A tibble: 348 x 4
#>    chrom   start     end .win_id
#>    <chr>   <int>   <int>   <int>
#>  1  chr1 9437053 9437063       1
#>  2  chr1 9437063 9437073       2
#>  3  chr1 9437073 9437083       3
#>  4  chr1 9437083 9437093       4
#>  5  chr1 9437093 9437103       5
#>  6  chr1 9437103 9437113       6
#>  7  chr1 9437113 9437123       7
#>  8  chr1 9437123 9437133       8
#>  9  chr1 9437133 9437143       9
#> 10  chr1 9437143 9437153      10
#> # ... with 338 more rows

arrange(res, desc(.win_id))
#> # A tibble: 348 x 4
#>    chrom    start      end .win_id
#>    <chr>    <int>    <int>   <int>
#>  1  chr1 86352125 86352127     146
#>  2  chr1 86352124 86352125     145
#>  3  chr1 86352123 86352124     144
#>  4  chr1 86352122 86352123     143
#>  5  chr1 86352121 86352122     142
#>  6  chr1 86352120 86352121     141
#>  7  chr1 86352119 86352120     140
#>  8  chr1 86352118 86352119     139
#>  9  chr1 86352117 86352118     138
#> 10  chr1 86352116 86352117     137
#> # ... with 338 more rows
```

Here's the behavior with the proposed fix. 

``` r
library(valr)
library(dplyr)

x <- tibble::tribble(
  ~chrom, ~start, ~end,
  "chr1", 9437053, 9438070,
  "chr1", 75360291, 75368579,
  "chr1", 86351980, 86352127
)

res <- bed_makewindows(x, num_win = 100)

res
#> # A tibble: 300 x 4
#>    chrom   start     end .win_id
#>    <chr>   <int>   <int>   <int>
#>  1  chr1 9437053 9437063       1
#>  2  chr1 9437063 9437073       2
#>  3  chr1 9437073 9437083       3
#>  4  chr1 9437083 9437093       4
#>  5  chr1 9437093 9437103       5
#>  6  chr1 9437103 9437113       6
#>  7  chr1 9437113 9437123       7
#>  8  chr1 9437123 9437133       8
#>  9  chr1 9437133 9437143       9
#> 10  chr1 9437143 9437153      10
#> # ... with 290 more rows

arrange(res, desc(.win_id))
#> # A tibble: 300 x 4
#>    chrom    start      end .win_id
#>    <chr>    <int>    <int>   <int>
#>  1  chr1  9438043  9438070     100
#>  2  chr1 75368409 75368579     100
#>  3  chr1 86352079 86352127     100
#>  4  chr1  9438033  9438043      99
#>  5  chr1 75368327 75368409      99
#>  6  chr1 86352078 86352079      99
#>  7  chr1  9438023  9438033      98
#>  8  chr1 75368245 75368327      98
#>  9  chr1 86352077 86352078      98
#> 10  chr1  9438013  9438023      97
#> # ... with 290 more rows
```

Created on 2018-01-24 by the [reprex package](http://reprex.tidyverse.org) (v0.1.1.9000).