### PR TITLE
More work on dplyr compatibility and performance gains on tibbles with many groups

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     ggplot2
 SystemRequirements: C++11
 LinkingTo:
-    Rcpp (>= 0.12.8),
+    Rcpp (>= 1.0.0),
     BH,
     plogr,
     bindrcpp,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,5 @@ BugReports: https://github.com/rnabioco/valr/issues
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 Remotes: 
-    tidyverse/dplyr
+    tidyverse/dplyr,
+    tidyverse/tibble

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: valr
 Type: Package
 Title: Genome Interval Arithmetic in R
-Version: 0.4.2
+Version: 0.4.2.9000
 Authors@R: c(
     person('Jay', 'Hesselberth', role = c('aut', 'cre'),
       email = 'jay.hesselberth@gmail.com',

--- a/R/bed_closest.r
+++ b/R/bed_closest.r
@@ -80,10 +80,13 @@ bed_closest <- function(x, y, overlap = TRUE,
   check_suffix(suffix)
 
   x <- bed_sort(x)
-  x <- group_by(x, chrom, add = TRUE)
-
   y <- bed_sort(y)
-  y <- group_by(y, chrom, add = TRUE)
+
+  groups_xy <- shared_groups(x, y)
+  groups_vars <- rlang::syms(c("chrom", groups_xy))
+
+  x <- group_by(x, !!! groups_vars)
+  y <- group_by(y, !!! groups_vars)
 
   suffix <- list(x = suffix[1], y = suffix[2])
 

--- a/R/bed_intersect.r
+++ b/R/bed_intersect.r
@@ -126,8 +126,12 @@ bed_intersect <- function(x, ..., invert = FALSE, suffix = c(".x", ".y")) {
 
   check_suffix(suffix)
 
-  x <- group_by(x, chrom, add = TRUE)
-  y <- group_by(y, chrom, add = TRUE)
+  # establish grouping with shared groups (and chrom)
+  groups_xy <- shared_groups(x, y)
+  groups_vars <- rlang::syms(c("chrom", groups_xy))
+
+  x <- group_by(x, !!! groups_vars)
+  y <- group_by(y, !!! groups_vars)
 
   suffix <- list(x = suffix[1], y = suffix[2])
 

--- a/R/bed_map.r
+++ b/R/bed_map.r
@@ -45,8 +45,11 @@ bed_map <- function(x, y, ..., min_overlap = 1) {
   .id_col_out <- str_c(.id_col, ".x")
 
   ## add chrom as a group
-  x <- group_by(x, chrom, add = TRUE)
-  y <- group_by(y, chrom, add = TRUE)
+  groups_xy <- shared_groups(x, y)
+  groups_vars <- rlang::syms(c("chrom", groups_xy))
+
+  x <- group_by(x, !!! groups_vars)
+  y <- group_by(y, !!! groups_vars)
 
   if (utils::packageVersion("dplyr") < "0.7.9.9000"){
     x <- update_groups(x)

--- a/R/bed_merge.r
+++ b/R/bed_merge.r
@@ -86,9 +86,12 @@ bed_merge <- function(x, max_dist = 0, ...) {
     res <- merge_impl(res, environment(), max_dist, collapse = TRUE)
     res <- select(res, !!! rlang::syms(c("chrom", "start", "end", groups_x)))
   }
-
+  res <- ungroup(res)
   # restore original grouping
-  res <- group_by(res, !!! rlang::syms(groups_x))
+  if(!is.null(groups_x)){
+    res <- group_by(res, !!! rlang::syms(groups_x))
+  }
+
   res <- reorder_names(res, x)
 
   attr(res, "merged") <- TRUE

--- a/R/bed_subtract.r
+++ b/R/bed_subtract.r
@@ -53,8 +53,11 @@ bed_subtract <- function(x, y, any = FALSE) {
   if (!is.tbl_interval(x)) x <- as.tbl_interval(x)
   if (!is.tbl_interval(y)) y <- as.tbl_interval(y)
 
-  x <- group_by(x, chrom, add = TRUE)
-  y <- group_by(y, chrom, add = TRUE)
+  groups_xy <- shared_groups(x, y)
+  groups_vars <- rlang::syms(c("chrom", groups_xy))
+
+  x <- group_by(x, !!! groups_vars)
+  y <- group_by(y, !!! groups_vars)
 
   # find groups not in y
   not_y_grps <- setdiff(get_labels(x), get_labels(y))

--- a/inst/include/DataFrameBuilder.h
+++ b/inst/include/DataFrameBuilder.h
@@ -74,11 +74,18 @@ public:
   }
 
   // apply common attributes to output dataframe
+  // by default groups are stripped and tbl_df is returned
   inline List format_df(int nrow) {
     List res = *this ;
     auto names = this->names ;
+
     set_rownames(res, nrow) ;
     res.attr("names") = names ;
+
+    if(Rf_inherits(res, "grouped_df")){
+      GroupedDataFrame::strip_groups(res) ;
+    }
+
     res.attr("class") = Rcpp::CharacterVector::create("tbl_df", "tbl", "data.frame") ;
     return res ;
   }

--- a/inst/include/dplyr/data/GroupedDataFrame.h
+++ b/inst/include/dplyr/data/GroupedDataFrame.h
@@ -229,6 +229,11 @@ public:
     return groups[groups.size() - 1] ;
   }
 
+  template <typename Data>
+  static void strip_groups(Data& x) {
+      x.attr("groups") = R_NilValue;
+  }
+
 private:
   DataFrame data_;
   DataFrame groups;

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,0 +1,243 @@
+#include "pch.h"
+#include <dplyr/main.h>
+
+#include <tools/hash.h>
+#include <tools/match.h>
+
+#include <dplyr/visitors/CharacterVectorOrderer.h>
+
+#include <dplyr/visitors/vector/visitor_impl.h>
+
+#include <dplyr/visitors/join/JoinVisitor.h>
+#include <dplyr/visitors/join/JoinVisitorImpl.h>
+#include <dplyr/visitors/join/DataFrameJoinVisitors.h>
+
+#include <tools/bad.h>
+
+namespace dplyr {
+
+DataFrameVisitors::DataFrameVisitors(const Rcpp::DataFrame& data_) :
+data(data_),
+visitors(),
+visitor_names(vec_names_or_empty(data))
+{
+
+  for (int i = 0; i < data.size(); i++) {
+    VectorVisitor* v = visitor(data[i]);
+    visitors.push_back(v);
+  }
+}
+
+DataFrameVisitors::DataFrameVisitors(const DataFrame& data_, const SymbolVector& names) :
+data(data_),
+visitors(),
+visitor_names(names)
+{
+
+  int n = names.size();
+  CharacterVector data_names = vec_names_or_empty(data);
+  IntegerVector indices = names.match_in_table(data_names);
+
+  for (int i = 0; i < n; i++) {
+    if (indices[i] == NA_INTEGER) {
+      bad_col(names[i], "is unknown");
+    }
+    SEXP column = data[indices[i] - 1];
+    visitors.push_back(visitor(column));
+  }
+
+}
+
+DataFrameVisitors::DataFrameVisitors(const DataFrame& data_, const IntegerVector& indices) :
+data(data_),
+visitors(),
+visitor_names()
+{
+
+  CharacterVector data_names = vec_names_or_empty(data);
+
+  int n = indices.size();
+  for (int i = 0; i < n; i++) {
+    int pos = check_range_one_based(indices[i], data.size());
+
+    VectorVisitor* v = visitor(data[pos - 1]);
+    visitors.push_back(v);
+    visitor_names.push_back(data_names[pos - 1]);
+  }
+}
+
+DataFrameVisitors::DataFrameVisitors(const DataFrame& data_,  int n) :
+data(data_),
+visitors(n),
+visitor_names(n)
+{
+
+  CharacterVector data_names = vec_names_or_empty(data);
+
+  for (int i = 0; i < n; i++) {
+    visitors[i] = visitor(data[i]);
+    visitor_names.set(i, data_names[i]);
+  }
+}
+
+DataFrameJoinVisitors::DataFrameJoinVisitors(const DataFrame& left_, const DataFrame& right_, const SymbolVector& names_left, const SymbolVector& names_right, bool warn_, bool na_match) :
+left(left_), right(right_),
+visitor_names_left(names_left),
+visitor_names_right(names_right),
+visitors(names_left.size()),
+warn(warn_)
+{
+  IntegerVector indices_left  = names_left.match_in_table(RCPP_GET_NAMES(left));
+  IntegerVector indices_right = names_right.match_in_table(RCPP_GET_NAMES(right));
+
+  const int nvisitors = indices_left.size();
+  if (indices_right.size() != nvisitors) {
+    stop("Different size of join column index vectors");
+  }
+
+  for (int i = 0; i < nvisitors; i++) {
+    const SymbolString& name_left  = names_left[i];
+    const SymbolString& name_right = names_right[i];
+
+    if (indices_left[i] == NA_INTEGER) {
+      stop("'%s' column not found in lhs, cannot join", name_left.get_utf8_cstring());
+    }
+    if (indices_right[i] == NA_INTEGER) {
+      stop("'%s' column not found in rhs, cannot join", name_right.get_utf8_cstring());
+    }
+
+    visitors[i] =
+      join_visitor(
+        Column(left[indices_left[i] - 1], name_left),
+        Column(right[indices_right[i] - 1], name_right),
+        warn, na_match
+      );
+  }
+}
+
+DataFrameJoinVisitors::DataFrameJoinVisitors(
+  const DataFrame& left_, const DataFrame& right_,
+  const IntegerVector& indices_left, const IntegerVector& indices_right,
+  bool warn_, bool na_match
+) :
+left(left_), right(right_),
+visitor_names_left(),
+visitor_names_right(),
+visitors(indices_left.size()),
+warn(warn_)
+{
+  if (indices_right.size() != size()) {
+    stop("Different size of join column index vectors");
+  }
+
+  SymbolVector left_names = left.names();
+  SymbolVector right_names = right.names();
+
+  for (int i = 0; i < size(); i++) {
+    const int index_left = check_range_one_based(indices_left[i], left.size());
+    const int index_right = check_range_one_based(indices_right[i], right.size());
+
+    const SymbolString& name_left = left_names[index_left - 1];
+    const SymbolString& name_right = right_names[index_right - 1];
+
+    visitors[i] =
+      join_visitor(
+        Column(left[index_left - 1], name_left),
+        Column(right[index_right - 1], name_right),
+        warn, na_match
+      );
+
+    visitor_names_left.push_back(name_left);
+    visitor_names_right.push_back(name_right);
+  }
+}
+
+JoinVisitor* DataFrameJoinVisitors::get(int k) const {
+  return visitors[k];
+}
+
+JoinVisitor* DataFrameJoinVisitors::get(const SymbolString& name) const {
+  for (int i = 0; i < size(); i++) {
+    if (name == visitor_names_left[i]) return get(i);
+  }
+  stop("visitor not found for name '%s' ", name.get_utf8_cstring());
+}
+
+int DataFrameJoinVisitors::size() const {
+  return visitors.size();
+}
+
+CharacterVectorOrderer::CharacterVectorOrderer(const CharacterVector& data) :
+orders(no_init(data.size()))
+{
+  int n = data.size();
+  if (n == 0) return;
+
+  dplyr_hash_set<SEXP> set(n);
+
+  // 1 - gather unique SEXP pointers from data
+  SEXP* p_data = Rcpp::internal::r_vector_start<STRSXP>(data);
+  SEXP previous = *p_data++;
+  set.insert(previous);
+  for (int i = 1; i < n; i++, p_data++) {
+    SEXP s = *p_data;
+
+    // we've just seen this string, keep going
+    if (s == previous) continue;
+
+    // is this string in the set already
+    set.insert(s);
+    previous = s;
+  }
+
+  // retrieve unique strings from the set
+  int n_uniques = set.size();
+  LOG_VERBOSE << "Sorting " <<  n_uniques << " unique character elements";
+
+  CharacterVector uniques(set.begin(), set.end());
+
+  static Function sort("sort", R_BaseEnv);
+  CharacterVector s_uniques = Language(sort, uniques).fast_eval();
+
+  // order the uniques with a callback to R
+  IntegerVector o = r_match(uniques, s_uniques);
+
+  // combine uniques and o into a hash map for fast retrieval
+  dplyr_hash_map<SEXP, int> map(n_uniques);
+  for (int i = 0; i < n_uniques; i++) {
+    map.insert(std::make_pair(uniques[i], o[i]));
+  }
+
+  // grab min ranks
+  p_data = Rcpp::internal::r_vector_start<STRSXP>(data);
+  previous = *p_data++;
+
+  int o_pos;
+  orders[0] = o_pos = map.find(previous)->second;
+
+  for (int i = 1; i < n; ++i, ++p_data) {
+    SEXP s = *p_data;
+    if (s == previous) {
+      orders[i] = o_pos;
+      continue;
+    }
+    previous = s;
+    orders[i] = o_pos = map.find(s)->second;
+  }
+
+}
+
+CharacterVector get_uniques(const CharacterVector& left, const CharacterVector& right) {
+  int nleft = left.size(), nright = right.size();
+  int n = nleft + nright;
+
+  CharacterVector big(no_init(n));
+  CharacterVector::iterator it = big.begin();
+  std::copy(left.begin(), left.end(), it);
+  std::copy(right.begin(), right.end(), it + nleft);
+
+  static Function unique("unique", R_BaseEnv);
+  return Language(unique, big).fast_eval();
+}
+
+}

--- a/src/dplyr_init.cpp
+++ b/src/dplyr_init.cpp
@@ -74,7 +74,7 @@ namespace dplyr {
 // SEXP symbols::double_colon = Rf_install("::");
 // SEXP symbols::na_rm = Rf_install("na.rm");
 SEXP symbols::new_env = Rf_install("new.env");
-// SEXP symbols::comment = Rf_install("comment");
+SEXP symbols::comment = Rf_install("comment");
 // SEXP symbols::groups = Rf_install("groups");
 // SEXP symbols::vars = Rf_install("vars");
 //

--- a/src/encoding.cpp
+++ b/src/encoding.cpp
@@ -1,0 +1,59 @@
+#include "pch.h"
+#include <dplyr/main.h>
+
+#include <tools/encoding.h>
+#include <tools/utils.h>
+
+namespace dplyr {
+
+R_xlen_t get_first_reencode_pos(const CharacterVector& x) {
+  R_xlen_t len = x.length();
+  for (R_xlen_t i = 0; i < len; ++i) {
+    SEXP xi = x[i];
+    if (xi != NA_STRING && !IS_ASCII(xi) && !IS_UTF8(xi)) {
+      return i;
+    }
+  }
+
+  return len;
+}
+
+CharacterVector reencode_char(SEXP x) {
+  if (Rf_isFactor(x)) return reencode_factor(x);
+
+  CharacterVector ret(x);
+  R_xlen_t first = get_first_reencode_pos(ret);
+  if (first >= ret.length()) return ret;
+
+  ret = clone(ret);
+
+  R_xlen_t len = ret.length();
+  for (R_xlen_t i = first; i < len; ++i) {
+    SEXP reti = ret[i];
+    if (reti != NA_STRING && !IS_ASCII(reti) && !IS_UTF8(reti)) {
+      ret[i] = String(Rf_translateCharUTF8(reti), CE_UTF8);
+    }
+  }
+
+  return ret;
+}
+
+CharacterVector reencode_factor(IntegerVector x) {
+  CharacterVector levels(reencode_char(get_levels(x)));
+  CharacterVector ret(x.length());
+
+  R_xlen_t nlevels = levels.length();
+
+  R_xlen_t len = x.length();
+  for (R_xlen_t i = 0; i < len; ++i) {
+    int xi = x[i];
+    if (xi <= 0 || xi > nlevels)
+      ret[i] = NA_STRING;
+    else
+      ret[i] = levels[xi - 1];
+  }
+
+  return ret;
+}
+
+}

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -58,222 +58,222 @@ void check_attribute_compatibility(const Column& left, const Column& right) {
   }
 }
 
-// template <int LHS_RTYPE, bool ACCEPT_NA_MATCH>
-// JoinVisitor* date_join_visitor_right(const Column& left, const Column& right) {
-//   switch (TYPEOF(right.get_data())) {
-//   case INTSXP:
-//     return new DateJoinVisitor<LHS_RTYPE, INTSXP, ACCEPT_NA_MATCH>(left, right);
-//   case REALSXP:
-//     return new DateJoinVisitor<LHS_RTYPE, REALSXP, ACCEPT_NA_MATCH>(left, right);
-//   default:
-//     stop("Date objects should be represented as integer or numeric");
-//   }
-// }
-//
-// template <bool ACCEPT_NA_MATCH>
-// JoinVisitor* date_join_visitor(const Column& left, const Column& right) {
-//   switch (TYPEOF(left.get_data())) {
-//   case INTSXP:
-//     return date_join_visitor_right<INTSXP, ACCEPT_NA_MATCH>(left, right);
-//   case REALSXP:
-//     return date_join_visitor_right<REALSXP, ACCEPT_NA_MATCH>(left, right);
-//   default:
-//     stop("Date objects should be represented as integer or numeric");
-//   }
-// }
-//
-// template <bool ACCEPT_NA_MATCH>
-// JoinVisitor* join_visitor(const Column& left, const Column& right, bool warn_) {
-//   // handle Date separately
-//   bool lhs_date = Rf_inherits(left.get_data(), "Date");
-//   bool rhs_date = Rf_inherits(right.get_data(), "Date");
-//
-//   switch (lhs_date + rhs_date) {
-//   case 2:
-//     return date_join_visitor<ACCEPT_NA_MATCH>(left, right);
-//   case 1:
-//     stop("cannot join a Date object with an object that is not a Date object");
-//   case 0:
-//     break;
-//   default:
-//     break;
-//   }
-//
-//   bool lhs_time = Rf_inherits(left.get_data(), "POSIXct");
-//   bool rhs_time = Rf_inherits(right.get_data(), "POSIXct");
-//   switch (lhs_time + rhs_time) {
-//   case 2:
-//     return new POSIXctJoinVisitor<ACCEPT_NA_MATCH>(left, right);
-//   case 1:
-//     stop("cannot join a POSIXct object with an object that is not a POSIXct object");
-//   case 0:
-//     break;
-//   default:
-//     break;
-//   }
-//
-//   switch (TYPEOF(left.get_data())) {
-//   case CPLXSXP:
-//   {
-//     switch (TYPEOF(right.get_data())) {
-//     case CPLXSXP:
-//       return new JoinVisitorImpl<CPLXSXP, CPLXSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//     default:
-//       break;
-//     }
-//     break;
-//   }
-//   case INTSXP:
-//   {
-//     bool lhs_factor = Rf_inherits(left.get_data(), "factor");
-//     switch (TYPEOF(right.get_data())) {
-//     case INTSXP:
-//     {
-//       bool rhs_factor = Rf_inherits(right.get_data(), "factor");
-//       if (lhs_factor && rhs_factor) {
-//         if (same_levels(left.get_data(), right.get_data())) {
-//           return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//         } else {
-//           warn_bad_var(
-//             left.get_name(), right.get_name(),
-//             "joining factors with different levels, coercing to character vector",
-//             warn_
-//           );
-//           return
-//             new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
-//               left.update_data(reencode_char(left.get_data())),
-//               right.update_data(reencode_char(right.get_data())),
-//               warn_
-//             );
-//         }
-//       } else if (!lhs_factor && !rhs_factor) {
-//         return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//       }
-//       break;
-//     }
-//     case REALSXP:
-//     {
-//       if (!lhs_factor && is_bare_vector(right.get_data())) {
-//         return new JoinVisitorImpl<INTSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//       }
-//       break;
-//       // what else: perhaps we can have INTSXP which is a Date and REALSXP which is a Date too ?
-//     }
-//     case LGLSXP:
-//     {
-//       if (!lhs_factor) {
-//         return new JoinVisitorImpl<INTSXP, LGLSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//       }
-//       break;
-//     }
-//     case STRSXP:
-//     {
-//       if (lhs_factor) {
-//         warn_bad_var(
-//           left.get_name(), right.get_name(),
-//           "joining factor and character vector, coercing into character vector",
-//           warn_
-//         );
-//         return
-//           new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
-//             left.update_data(reencode_char(left.get_data())),
-//             right.update_data(reencode_char(right.get_data())),
-//             warn_
-//           );
-//       }
-//     }
-//     default:
-//       break;
-//     }
-//     break;
-//   }
-//   case REALSXP:
-//   {
-//     switch (TYPEOF(right.get_data())) {
-//     case REALSXP:
-//       return new JoinVisitorImpl<REALSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//     case INTSXP:
-//       return new JoinVisitorImpl<REALSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//     default:
-//       break;
-//     }
-//
-//   }
-//   case LGLSXP:
-//   {
-//     switch (TYPEOF(right.get_data())) {
-//     case LGLSXP:
-//       return new JoinVisitorImpl<LGLSXP, LGLSXP, ACCEPT_NA_MATCH> (left, right, warn_);
-//     case INTSXP:
-//       return new JoinVisitorImpl<LGLSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//     case REALSXP:
-//       return new JoinVisitorImpl<LGLSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, warn_);
-//     default:
-//       break;
-//     }
-//     break;
-//   }
-//   case STRSXP:
-//   {
-//     switch (TYPEOF(right.get_data())) {
-//     case INTSXP:
-//     {
-//       if (Rf_inherits(right.get_data(), "factor")) {
-//         warn_bad_var(
-//           left.get_name(), right.get_name(),
-//           "joining character vector and factor, coercing into character vector",
-//           warn_
-//         );
-//         return
-//           new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
-//             left.update_data(reencode_char(left.get_data())),
-//             right.update_data(reencode_char(right.get_data())),
-//             warn_
-//           );
-//       }
-//       break;
-//     }
-//     case STRSXP:
-//     {
-//       return
-//         new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
-//           left.update_data(reencode_char(left.get_data())),
-//           right.update_data(reencode_char(right.get_data())),
-//           warn_
-//         );
-//     }
-//     default:
-//       break;
-//     }
-//     break;
-//   }
-//   case RAWSXP:
-//   {
-//     switch (TYPEOF(right.get_data())) {
-//     case RAWSXP:
-//     {
-//       return new JoinVisitorImpl<RAWSXP, RAWSXP, ACCEPT_NA_MATCH> (left, right, warn_);
-//     }
-//     default:
-//       break;
-//     }
-//   }
-//   default:
-//     break;
-//   }
-//
-//   stop(
-//     "Can't join on '%s' x '%s' because of incompatible types (%s / %s)",
-//     left.get_name().get_utf8_cstring(), right.get_name().get_utf8_cstring(),
-//     get_single_class(left.get_data()), get_single_class(right.get_data())
-//   );
-// }
-//
-// JoinVisitor* join_visitor(const Column& left, const Column& right, bool warn, bool accept_na_match) {
-//   if (accept_na_match)
-//     return join_visitor<true>(left, right, warn);
-//   else
-//     return join_visitor<false>(left, right, warn);
-// }
+template <int LHS_RTYPE, bool ACCEPT_NA_MATCH>
+JoinVisitor* date_join_visitor_right(const Column& left, const Column& right) {
+  switch (TYPEOF(right.get_data())) {
+  case INTSXP:
+    return new DateJoinVisitor<LHS_RTYPE, INTSXP, ACCEPT_NA_MATCH>(left, right);
+  case REALSXP:
+    return new DateJoinVisitor<LHS_RTYPE, REALSXP, ACCEPT_NA_MATCH>(left, right);
+  default:
+    stop("Date objects should be represented as integer or numeric");
+  }
+}
+
+template <bool ACCEPT_NA_MATCH>
+JoinVisitor* date_join_visitor(const Column& left, const Column& right) {
+  switch (TYPEOF(left.get_data())) {
+  case INTSXP:
+    return date_join_visitor_right<INTSXP, ACCEPT_NA_MATCH>(left, right);
+  case REALSXP:
+    return date_join_visitor_right<REALSXP, ACCEPT_NA_MATCH>(left, right);
+  default:
+    stop("Date objects should be represented as integer or numeric");
+  }
+}
+
+template <bool ACCEPT_NA_MATCH>
+JoinVisitor* join_visitor(const Column& left, const Column& right, bool warn_) {
+  // handle Date separately
+  bool lhs_date = Rf_inherits(left.get_data(), "Date");
+  bool rhs_date = Rf_inherits(right.get_data(), "Date");
+
+  switch (lhs_date + rhs_date) {
+  case 2:
+    return date_join_visitor<ACCEPT_NA_MATCH>(left, right);
+  case 1:
+    stop("cannot join a Date object with an object that is not a Date object");
+  case 0:
+    break;
+  default:
+    break;
+  }
+
+  bool lhs_time = Rf_inherits(left.get_data(), "POSIXct");
+  bool rhs_time = Rf_inherits(right.get_data(), "POSIXct");
+  switch (lhs_time + rhs_time) {
+  case 2:
+    return new POSIXctJoinVisitor<ACCEPT_NA_MATCH>(left, right);
+  case 1:
+    stop("cannot join a POSIXct object with an object that is not a POSIXct object");
+  case 0:
+    break;
+  default:
+    break;
+  }
+
+  switch (TYPEOF(left.get_data())) {
+  case CPLXSXP:
+  {
+    switch (TYPEOF(right.get_data())) {
+    case CPLXSXP:
+      return new JoinVisitorImpl<CPLXSXP, CPLXSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+    default:
+      break;
+    }
+    break;
+  }
+  case INTSXP:
+  {
+    bool lhs_factor = Rf_inherits(left.get_data(), "factor");
+    switch (TYPEOF(right.get_data())) {
+    case INTSXP:
+    {
+      bool rhs_factor = Rf_inherits(right.get_data(), "factor");
+      if (lhs_factor && rhs_factor) {
+        if (same_levels(left.get_data(), right.get_data())) {
+          return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+        } else {
+          warn_bad_var(
+            left.get_name(), right.get_name(),
+            "joining factors with different levels, coercing to character vector",
+            warn_
+          );
+          return
+            new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+              left.update_data(reencode_char(left.get_data())),
+              right.update_data(reencode_char(right.get_data())),
+              warn_
+            );
+        }
+      } else if (!lhs_factor && !rhs_factor) {
+        return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+      }
+      break;
+    }
+    case REALSXP:
+    {
+      if (!lhs_factor && is_bare_vector(right.get_data())) {
+        return new JoinVisitorImpl<INTSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+      }
+      break;
+      // what else: perhaps we can have INTSXP which is a Date and REALSXP which is a Date too ?
+    }
+    case LGLSXP:
+    {
+      if (!lhs_factor) {
+        return new JoinVisitorImpl<INTSXP, LGLSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+      }
+      break;
+    }
+    case STRSXP:
+    {
+      if (lhs_factor) {
+        warn_bad_var(
+          left.get_name(), right.get_name(),
+          "joining factor and character vector, coercing into character vector",
+          warn_
+        );
+        return
+          new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+            left.update_data(reencode_char(left.get_data())),
+            right.update_data(reencode_char(right.get_data())),
+            warn_
+          );
+      }
+    }
+    default:
+      break;
+    }
+    break;
+  }
+  case REALSXP:
+  {
+    switch (TYPEOF(right.get_data())) {
+    case REALSXP:
+      return new JoinVisitorImpl<REALSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+    case INTSXP:
+      return new JoinVisitorImpl<REALSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+    default:
+      break;
+    }
+
+  }
+  case LGLSXP:
+  {
+    switch (TYPEOF(right.get_data())) {
+    case LGLSXP:
+      return new JoinVisitorImpl<LGLSXP, LGLSXP, ACCEPT_NA_MATCH> (left, right, warn_);
+    case INTSXP:
+      return new JoinVisitorImpl<LGLSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+    case REALSXP:
+      return new JoinVisitorImpl<LGLSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, warn_);
+    default:
+      break;
+    }
+    break;
+  }
+  case STRSXP:
+  {
+    switch (TYPEOF(right.get_data())) {
+    case INTSXP:
+    {
+      if (Rf_inherits(right.get_data(), "factor")) {
+        warn_bad_var(
+          left.get_name(), right.get_name(),
+          "joining character vector and factor, coercing into character vector",
+          warn_
+        );
+        return
+          new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+            left.update_data(reencode_char(left.get_data())),
+            right.update_data(reencode_char(right.get_data())),
+            warn_
+          );
+      }
+      break;
+    }
+    case STRSXP:
+    {
+      return
+        new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+          left.update_data(reencode_char(left.get_data())),
+          right.update_data(reencode_char(right.get_data())),
+          warn_
+        );
+    }
+    default:
+      break;
+    }
+    break;
+  }
+  case RAWSXP:
+  {
+    switch (TYPEOF(right.get_data())) {
+    case RAWSXP:
+    {
+      return new JoinVisitorImpl<RAWSXP, RAWSXP, ACCEPT_NA_MATCH> (left, right, warn_);
+    }
+    default:
+      break;
+    }
+  }
+  default:
+    break;
+  }
+
+  stop(
+    "Can't join on '%s' x '%s' because of incompatible types (%s / %s)",
+    left.get_name().get_utf8_cstring(), right.get_name().get_utf8_cstring(),
+    get_single_class(left.get_data()), get_single_class(right.get_data())
+  );
+}
+
+JoinVisitor* join_visitor(const Column& left, const Column& right, bool warn, bool accept_na_match) {
+  if (accept_na_match)
+    return join_visitor<true>(left, right, warn);
+  else
+    return join_visitor<false>(left, right, warn);
+}
 
 }

--- a/src/valr_utils.cpp
+++ b/src/valr_utils.cpp
@@ -24,3 +24,53 @@ GroupedDataFrame::GroupedDataFrame(DataFrame x):
   groups(data_.attr("groups"))
 {}
 
+
+DataFrame extract_groups(const DataFrame& x) {
+  int n = x.ncol() - 1;
+  CharacterVector df_names = x.names() ;
+
+  List res(n);
+  CharacterVector new_names(n) ;
+
+  for (int i = 0; i < n; i++) {
+    res[i] = x[i] ;
+    new_names[i] = df_names[i] ;
+  }
+
+  set_rownames(res, x.nrow()) ;
+  res.names() = new_names ;
+  res.attr("class") = "data.frame" ;
+  return res;
+}
+
+// Perform intersect between group_data of groupeddataframes and return the
+// row indicies shared between both dataframes. Used to identify matching
+// groups for two table operations i.e. intersect_impl.
+// Based on intersect_data_frame from dplyr
+std::vector<int> shared_row_indexes(const GroupedDataFrame& x,
+                                    const GroupedDataFrame& y) {
+
+  DataFrame grp_x = extract_groups(x.group_data()) ;
+  DataFrame grp_y = extract_groups(y.group_data()) ;
+
+  typedef VisitorSetIndexSet<DataFrameJoinVisitors> Set;
+
+  SymbolVector x_names = grp_x.names();
+  DataFrameJoinVisitors visitors(grp_x, grp_y, x_names, x_names, true, true);
+  Set set(visitors);
+
+  train_insert(set, grp_x.nrows());
+
+  std::vector<int> indices ;
+  int n_y = grp_y.nrows();
+  for (int i = 0; i < n_y; i++) {
+    Set::iterator it = set.find(-i - 1);
+    if (it != set.end()) {
+      indices.push_back(*it);
+      set.erase(it);
+    }
+  }
+  return indices ;
+}
+
+

--- a/tests/testthat/test_factors.R
+++ b/tests/testthat/test_factors.R
@@ -21,7 +21,7 @@ test_that("factor types for groups are handled the same as character", {
 
 test_that("mixing factor and character vectors for grouping works", {
   res_x <- bed_intersect(x_grpd, x_grpd)
-  res_mixed <- bed_intersect(x_grpd, x_facs_grpd)
+  expect_warning(res_mixed <- bed_intersect(x_grpd, x_facs_grpd))
   expect_true(all(res_x == res_mixed))
 })
 
@@ -31,9 +31,8 @@ test_that("factors with no entries are handled ", {
     filter(strand == "+", chrom == "chr1") %>%
     group_by(strand)
 
-  res_x <- bed_intersect(x, x_empty_groups)
+  res_x <- bed_intersect(x_facs_grpd, x_empty_groups)
   expect_true(all(res_x$chrom == "chr1"))
   expect_true(all(res_x$strand.x == "+" && res_x$strand.y == "+"))
+
 })
-
-

--- a/tests/testthat/test_groups.r
+++ b/tests/testthat/test_groups.r
@@ -1,5 +1,42 @@
 context("dplyr grouping")
 
+genome <- read_genome(valr_example("hg19.chrom.sizes.gz"))
+seed <- 1010486
+x <- bed_random(genome, n = 1e4, seed = seed)
+x$strand <- rep(c("+", "_"), 5e3)
+y <- x
+
+x_grpd <- group_by(x, strand)
+y_grpd <- group_by(y, strand)
+
+
+test_that("mismatched groups are dropped by two table verbs", {
+   res1 <- bed_closest(x, y_grpd)
+   res2 <- bed_closest(x_grpd, y)
+   expect_equal(res1, res2)
+   expect_equal(nrow(res1), 20284)
+
+   res1 <- bed_intersect(x, y_grpd)
+   res2 <- bed_intersect(x_grpd, y)
+   expect_equal(res1, res2)
+   expect_equal(nrow(res1), 10076)
+
+   res1 <- bed_map(x, y_grpd, .n = n())
+   res2 <- bed_map(x_grpd, y, .n = n())
+   expect_equal(res1, res2)
+   expect_equal(nrow(res1), 10000)
+
+   res1 <- bed_subtract(x, y_grpd)
+   res2 <- bed_subtract(x_grpd, y)
+   expect_equal(res1, res2)
+   expect_equal(nrow(res1), 0)
+
+   res1 <- bed_window(x, y_grpd, genome)
+   res2 <- bed_window(x_grpd, y, genome)
+   expect_equal(res1, res2)
+   expect_equal(nrow(res1), 10076)
+})
+
 ## dplyr v0.7.9 and earlier style grouped data_frame
 df_old <- structure(
     list(

--- a/tests/testthat/test_groups.r
+++ b/tests/testthat/test_groups.r
@@ -1,9 +1,9 @@
 context("dplyr grouping")
 
 genome <- read_genome(valr_example("hg19.chrom.sizes.gz"))
-seed <- 1010486
-x <- bed_random(genome, n = 1e4, seed = seed)
-x$strand <- rep(c("+", "_"), 5e3)
+genome <- read_genome(valr_example("hg19.chrom.sizes.gz"))
+
+x <- read_bed(valr_example("6fields.bed.gz"), n_fields = 6)
 y <- x
 
 x_grpd <- group_by(x, strand)
@@ -11,30 +11,30 @@ y_grpd <- group_by(y, strand)
 
 
 test_that("mismatched groups are dropped by two table verbs", {
-   res1 <- bed_closest(x, y_grpd)
-   res2 <- bed_closest(x_grpd, y)
-   expect_equal(res1, res2)
-   expect_equal(nrow(res1), 20284)
+  res1 <- bed_closest(x, y_grpd)
+  res2 <- bed_closest(x_grpd, y)
+  expect_equal(res1, res2)
+  expect_equal(nrow(res1), 26)
 
-   res1 <- bed_intersect(x, y_grpd)
-   res2 <- bed_intersect(x_grpd, y)
-   expect_equal(res1, res2)
-   expect_equal(nrow(res1), 10076)
+  res1 <- bed_intersect(x, y_grpd)
+  res2 <- bed_intersect(x_grpd, y)
+  expect_equal(res1, res2)
+  expect_equal(nrow(res1), 16)
 
-   res1 <- bed_map(x, y_grpd, .n = n())
-   res2 <- bed_map(x_grpd, y, .n = n())
-   expect_equal(res1, res2)
-   expect_equal(nrow(res1), 10000)
+  res1 <- bed_map(x, y_grpd, .n = n())
+  res2 <- bed_map(x_grpd, y, .n = n())
+  expect_equal(res1, res2)
+  expect_equal(nrow(res1), 10)
 
-   res1 <- bed_subtract(x, y_grpd)
-   res2 <- bed_subtract(x_grpd, y)
-   expect_equal(res1, res2)
-   expect_equal(nrow(res1), 0)
+  res1 <- bed_subtract(x, y_grpd)
+  res2 <- bed_subtract(x_grpd, y)
+  expect_equal(res1, res2)
+  expect_equal(nrow(res1), 0)
 
-   res1 <- bed_window(x, y_grpd, genome)
-   res2 <- bed_window(x_grpd, y, genome)
-   expect_equal(res1, res2)
-   expect_equal(nrow(res1), 10076)
+  res1 <- bed_window(x, y_grpd, genome)
+  res2 <- bed_window(x_grpd, y, genome)
+  expect_equal(res1, res2)
+  expect_equal(nrow(res1), 16)
 })
 
 ## dplyr v0.7.9 and earlier style grouped data_frame


### PR DESCRIPTION
This PR refactors the `group_apply` function to limit the number of rowwise comparisons necessary prior to applying the function. The `compare_rows` function becomes a bottleneck when there are many groups. 

Intersections are very slow with 1k groups:
``` r
library(valr)
library(tibble)

## make 1,000 groups
chrom <- paste0("chr", 1:1e3)
set.seed(42)
start <- sample(1:1e6, 1e3)
end <- start + 1000

bed <- tibble(chrom, start, end)

bed_intersect(bed, bed)
#> # A tibble: 1,000 x 6
#>    chrom   start.x  end.x start.y  end.y .overlap
#>    <chr>     <int>  <dbl>   <int>  <dbl>    <int>
#>  1 chr1     914807 915807  914807 915807     1000
#>  2 chr10    705059 706059  705059 706059     1000
#>  3 chr100   619098 620098  619098 620098     1000
#>  4 chr1000    7411   8411    7411   8411     1000
#>  5 chr101   626183 627183  626183 627183     1000
#>  6 chr102   217136 218136  217136 218136     1000
#>  7 chr103   216546 217546  216546 217546     1000
#>  8 chr104   388905 389905  388905 389905     1000
#>  9 chr105   942358 943358  942358 943358     1000
#> 10 chr106   962507 963507  962507 963507     1000
#> # … with 990 more rows

microbenchmark::microbenchmark(bed_intersect(bed, bed),
                               times = 1,
                               unit = 's')
#> Unit: seconds
#>                     expr      min       lq     mean   median       uq
#>  bed_intersect(bed, bed) 35.99777 35.99777 35.99777 35.99777 35.99777
#>       max neval
#>  35.99777     1
```

To fix this issue I've refactored `group_apply` to only operate on matched x and y groups. A new cpp function `shared_row_indexes` (built on dplyr cpp functions) identifies the indexes of shared x and y groups, allowing for iteration only over the relevant groups.

Performance with this PR is much improved.

``` r
library(valr)
library(tibble)

## make 1,000 groups
chrom <- paste0("chr", 1:1e3)
set.seed(42)
start <- sample(1:1e6, 1e3)
end <- start + 1000

bed <- tibble(chrom, start, end)

bed_intersect(bed, bed)
#> # A tibble: 1,000 x 6
#>    chrom   start.x  end.x start.y  end.y .overlap
#>    <chr>     <int>  <dbl>   <int>  <dbl>    <int>
#>  1 chr1     914807 915807  914807 915807     1000
#>  2 chr10    705059 706059  705059 706059     1000
#>  3 chr100   619098 620098  619098 620098     1000
#>  4 chr1000    7411   8411    7411   8411     1000
#>  5 chr101   626183 627183  626183 627183     1000
#>  6 chr102   217136 218136  217136 218136     1000
#>  7 chr103   216546 217546  216546 217546     1000
#>  8 chr104   388905 389905  388905 389905     1000
#>  9 chr105   942358 943358  942358 943358     1000
#> 10 chr106   962507 963507  962507 963507     1000
#> # … with 990 more rows

microbenchmark::microbenchmark(bed_intersect(bed, bed),
                               times = 1,
                               unit = 's')
#> Unit: seconds
#>                     expr        min         lq       mean     median
#>  bed_intersect(bed, bed) 0.01893517 0.01893517 0.01893517 0.01893517
#>          uq        max neval
#>  0.01893517 0.01893517     1
```

This PR also includes additional work on `dplyr `compatibility. I am going to keep working on simplifying the `dplyr` interface prior to proposing to merge into master. However, as it stands this version builds, passes tests, and checks against the latest dplyr master. 


