### PR TITLE
 fix extra interval reporting in bed_closest()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # valr 0.5.0.9000
 
+## Bug fixes
+
+* Fixed `bed_closest()` to prevent erroneous intervals being reported when adjacent closest intervals are present in the `y` table. (#348)
+
 # valr 0.5.0
 
 ## Major changes 

--- a/inst/include/IntervalTree.h
+++ b/inst/include/IntervalTree.h
@@ -243,8 +243,8 @@ public:
 
   intervalVector findClosest(K start, K stop) const {
     intervalVector closest ;
-    std::pair<int, intervalVector> min_dist_l, min_dist_r;
-    this->findClosest(start, stop, closest, min_dist_l, min_dist_r) ;
+    std::pair<int, intervalVector> min_dist;
+    this->findClosest(start, stop, closest, min_dist) ;
     return closest;
   }
 
@@ -254,10 +254,11 @@ public:
     if (!intervals.empty() && !(stop < intervals.front().start)) {
       for (typename intervalVector::const_iterator i = intervals.begin(); i != intervals.end(); ++i) {
         const interval& interval = *i;
-        if (interval.stop >= start && interval.start <= stop) {
+        if (interval.stop > start && interval.start < stop) {
+          // adjacent intervals are considered non-overlappping
           closest.push_back(interval);
-        } else if (stop < interval.start) {
-          // finddistance on left
+        } else if (stop <= interval.start) {
+          // find distance on left
           int ivl_dist_l = interval.start - stop ;
           // if smaller than best min dist found update pair with dist and intervals
           if (ivl_dist_l < min_dist.first) {
@@ -268,7 +269,7 @@ public:
             // if same dist append intervals
             min_dist.second.push_back(interval) ;
           }
-        } else if (start > interval.stop) {
+        } else if (start >= interval.stop) {
           // find distance on right
           int ivl_dist_r = start - interval.stop ;
           // if smaller than best min dist found update pair with dist and intervals
@@ -282,16 +283,16 @@ public:
           }
         }
       }
-    }  else if (!intervals.empty()  && (stop < intervals.front().start)) {
+    }  else if (!intervals.empty()  && (stop <= intervals.front().start)) {
       for (typename intervalVector::const_iterator i = intervals.begin(); i != intervals.end(); ++i) {
         const interval& interval = *i;
         if (interval.start > intervals.front().start) {
           continue ;
         } else {
-          // finddistance on left
+          // find distance on left
           int ivl_dist_l = interval.start - stop ;
           // if smaller than best min dist found update pair with dist and intervals
-          if (ivl_dist_l < min_dist.first) {
+          if (ivl_dist_l <= min_dist.first) {
             min_dist.first = ivl_dist_l;
             min_dist.second.clear() ;
             min_dist.second.push_back(interval) ;

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -16,9 +16,7 @@ test_that("1bp closer, check for off-by-one errors", {
   )
   res <- bed_closest(x, y)
   expect_equal(nrow(res), 3)
-  expect_true(res[1, ]$.dist == -1)
-  expect_true(res[2, ]$.dist == 0)
-  expect_true(res[3, ]$.dist == 1)
+  expect_true(all(c(0, -1, 1) %in% res$.dist))
 })
 
 test_that("reciprocal test of 1bp closer, check for off-by-one errors", {
@@ -35,9 +33,7 @@ test_that("reciprocal test of 1bp closer, check for off-by-one errors", {
   )
   res <- bed_closest(y, x)
   expect_equal(nrow(res), 3)
-  expect_true(res[1, ]$.dist == 1)
-  expect_true(res[2, ]$.dist == 0)
-  expect_true(res[3, ]$.dist == -1)
+  expect_true(all(c(0, -1, 1) %in% res$.dist))
 })
 
 test_that("0bp apart closer, check for off-by-one errors", {
@@ -54,9 +50,7 @@ test_that("0bp apart closer, check for off-by-one errors", {
   )
   res <- bed_closest(x, y)
   expect_equal(nrow(res), 3)
-  expect_true(res[1, ]$.dist == -1)
-  expect_true(res[2, ]$.dist == 0)
-  expect_true(res[3, ]$.dist == 1)
+  expect_true(all(c(0, -1, 1) %in% res$.dist))
 })
 
 test_that("reciprocal of 0bp apart closer, check for off-by-one errors", {
@@ -75,9 +69,7 @@ test_that("reciprocal of 0bp apart closer, check for off-by-one errors", {
   res2 <- bed_closest(x, y)
   expect_equal(nrow(res), 3)
   expect_equal(nrow(res), 3)
-  expect_true(res[1, ]$.dist == 1)
-  expect_true(res[2, ]$.dist == 0)
-  expect_true(res[3, ]$.dist == -1)
+  expect_true(all(c(0, -1, 1) %in% res$.dist))
 })
 
 test_that("check that first left interval at index 0 is not lost", {
@@ -545,6 +537,23 @@ test_that("check ties, single db", {
     ~ chrom, ~ start, ~ end, ~ group, ~ score, ~ strand,
     "chr1", 8, 9, "b1", 1, "+",
     "chr1", 21, 22, "b2", 1, "-"
+  )
+  res <- bed_closest(x, y)
+  expect_true(nrow(res) == 2)
+})
+
+test_that("check reporting of adjacent intervals issue #348", {
+  x <- tibble::tribble(
+    ~ chrom, ~ start, ~ end,
+    "chr1", 10, 20
+  )
+
+  y <- tibble::tribble(
+    ~ chrom, ~ start, ~ end,
+    "chr1", 8, 9,
+    "chr1", 9, 10,
+    "chr1", 20, 21,
+    "chr1", 21, 22
   )
   res <- bed_closest(x, y)
   expect_true(nrow(res) == 2)


### PR DESCRIPTION
On current master
``` r
library(valr)

x <- tibble::tribble(
  ~ chrom, ~ start, ~ end,
  "chr1", 10, 20
)

y <- tibble::tribble(
  ~ chrom, ~ start, ~ end,
  "chr1", 8, 9,
  "chr1", 9, 10,
  "chr1", 20, 21,
  "chr1", 21, 22
)
res <- bed_closest(x, y)

res
#> # A tibble: 4 x 7
#>   chrom start.x end.x start.y end.y .overlap .dist
#>   <chr>   <dbl> <dbl>   <dbl> <dbl>    <int> <int>
#> 1 chr1       10    20       9    10        0    -1
#> 2 chr1       10    20      20    21        0     1
#> 3 chr1       10    20       8     9        0    -2
#> 4 chr1       10    20      21    22        0     2
```

<sup>Created on 2019-03-22 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

With PR:
``` r
library(valr)

x <- tibble::tribble(
  ~ chrom, ~ start, ~ end,
  "chr1", 10, 20
)

y <- tibble::tribble(
  ~ chrom, ~ start, ~ end,
  "chr1", 8, 9,
  "chr1", 9, 10,
  "chr1", 20, 21,
  "chr1", 21, 22
)
res <- bed_closest(x, y)

res
#> # A tibble: 2 x 7
#>   chrom start.x end.x start.y end.y .overlap .dist
#>   <chr>   <dbl> <dbl>   <dbl> <dbl>    <int> <int>
#> 1 chr1       10    20       9    10        0    -1
#> 2 chr1       10    20      20    21        0     1
```

<sup>Created on 2019-03-22 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>