### PR TITLE
replace arrange with radix sort

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # valr 0.5.0.9000
 
+## Minor changes
+
+* `bed_sort()` now uses base R sorting with the `radix` method for increased speed. (#353)
+
 ## Bug fixes
 
 * Fixed `bed_closest()` to prevent erroneous intervals being reported when adjacent closest intervals are present in the `y` table. (#348)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Minor changes
 
+* The `sort_by` argument of `bed_random()` has been changed to `sorted`, and will now by default
+use `bed_sort()` to sort the output, rather than rely on naming the sorting columns. Sorting can
+be suppressed by using `sorted = FALSE`. 
+
 * `bed_sort()` now uses base R sorting with the `radix` method for increased speed. (#353)
 
 ## Bug fixes

--- a/R/bed_random.r
+++ b/R/bed_random.r
@@ -3,10 +3,10 @@
 #' @param genome [tbl_genome()]
 #' @param length length of intervals
 #' @param n number of intervals to generate
-#' @param sort_by sorting variables
 #' @param seed seed RNG for reproducible intervals
+#' @param sorted return sorted output
 #'
-#' @details Sorting can be suppressed with `sort_by = NULL`.
+#' @details Sorting can be suppressed with `sorted = FALSE`.
 #'
 #' @return [tbl_interval()]
 #'
@@ -26,14 +26,13 @@
 #' bed_random(genome, seed = 10104)
 #'
 #' # sorting can be suppressed
-#' bed_random(genome, sort_by = NULL, seed = 10104)
+#' bed_random(genome, sorted = FALSE, seed = 10104)
 #'
 #' # 500 random intervals of length 500
 #' bed_random(genome, length = 500, n = 500, seed = 10104)
 #'
 #' @export
-bed_random <- function(genome, length = 1000, n = 1e6,
-                       sort_by = c("chrom", "start"), seed = 0) {
+bed_random <- function(genome, length = 1000, n = 1e6, seed = 0, sorted = TRUE) {
   if (!is.tbl_genome(genome)) genome <- as.tbl_genome(genome)
 
   if (!all(genome$size > length)) {
@@ -42,9 +41,8 @@ bed_random <- function(genome, length = 1000, n = 1e6,
 
   out <- random_impl(genome, length, n, seed)
 
-  if (!is.null(sort_by) && length(sort_by) > 0) {
-    sort_syms <- rlang::syms(sort_by)
-    out <- arrange(out, !!! sort_syms)
+  if (sorted) {
+    out <- bed_sort(out)
   }
 
   out <- as.tbl_interval(out)

--- a/R/bed_sort.r
+++ b/R/bed_sort.r
@@ -42,32 +42,36 @@ bed_sort <- function(x, by_size = FALSE, by_chrom = FALSE, reverse = FALSE) {
 
     if (by_chrom) {
       if (reverse) {
-        res <- arrange(res, chrom, desc(.size))
+        res <- res[order(res$chrom, -res$.size, method = "radix"), ]
+      #  res <- arrange(res, chrom, desc(.size))
       } else {
-        res <- arrange(res, chrom, .size)
+        res <- res[order(res$chrom, res$.size, method = "radix"), ]
+      #  res <- arrange(res, chrom, .size)
       }
     } else {
       if (reverse) {
-        res <- arrange(res, desc(.size))
+        res <- res[order(-res$.size, method = "radix"), ]
+      #  res <- arrange(res, desc(.size))
       } else {
-        res <- arrange(res, .size)
+        res <- res[order(res$.size,  method = "radix"), ]
+       # res <- arrange(res, .size)
       }
     }
-
-
 
     # remove .size column and groups in result
     res <- select(res, -.size)
   } else {
-    if (by_chrom) {
-      res <- group_by(x, chrom)
-    }
 
     # sort by coordinate
     if (reverse) {
-      res <- arrange(x, chrom, desc(start))
+      res <- x[order(x$chrom, -x$start,
+                       method = "radix"), ]
+
+   #   res <- arrange(x, chrom, desc(start))
     } else {
-      res <- arrange(x, chrom, start, end)
+      res <- x[order(x$chrom, x$start, x$end,
+                       method = "radix"), ]
+     # res <- arrange(x, chrom, start, end)
     }
   }
 

--- a/R/bed_sort.r
+++ b/R/bed_sort.r
@@ -43,35 +43,27 @@ bed_sort <- function(x, by_size = FALSE, by_chrom = FALSE, reverse = FALSE) {
     if (by_chrom) {
       if (reverse) {
         res <- res[order(res$chrom, -res$.size, method = "radix"), ]
-      #  res <- arrange(res, chrom, desc(.size))
       } else {
         res <- res[order(res$chrom, res$.size, method = "radix"), ]
-      #  res <- arrange(res, chrom, .size)
       }
     } else {
       if (reverse) {
         res <- res[order(-res$.size, method = "radix"), ]
-      #  res <- arrange(res, desc(.size))
       } else {
-        res <- res[order(res$.size,  method = "radix"), ]
-       # res <- arrange(res, .size)
+        res <- res[order(res$.size, method = "radix"), ]
       }
     }
 
     # remove .size column and groups in result
     res <- select(res, -.size)
   } else {
-
     # sort by coordinate
     if (reverse) {
       res <- x[order(x$chrom, -x$start,
                        method = "radix"), ]
-
-   #   res <- arrange(x, chrom, desc(start))
     } else {
       res <- x[order(x$chrom, x$start, x$end,
                        method = "radix"), ]
-     # res <- arrange(x, chrom, start, end)
     }
   }
 

--- a/man/bed_random.Rd
+++ b/man/bed_random.Rd
@@ -4,13 +4,7 @@
 \alias{bed_random}
 \title{Generate randomly placed intervals on a genome.}
 \usage{
-bed_random(
-  genome,
-  length = 1000,
-  n = 1e+06,
-  sort_by = c("chrom", "start"),
-  seed = 0
-)
+bed_random(genome, length = 1000, n = 1e+06, seed = 0, sorted = TRUE)
 }
 \arguments{
 \item{genome}{\code{\link[=tbl_genome]{tbl_genome()}}}
@@ -19,9 +13,9 @@ bed_random(
 
 \item{n}{number of intervals to generate}
 
-\item{sort_by}{sorting variables}
-
 \item{seed}{seed RNG for reproducible intervals}
+
+\item{sorted}{return sorted output}
 }
 \value{
 \code{\link[=tbl_interval]{tbl_interval()}}
@@ -30,7 +24,7 @@ bed_random(
 Generate randomly placed intervals on a genome.
 }
 \details{
-Sorting can be suppressed with \code{sort_by = NULL}.
+Sorting can be suppressed with \code{sorted = FALSE}.
 }
 \examples{
 genome <- trbl_genome(
@@ -44,7 +38,7 @@ genome <- trbl_genome(
 bed_random(genome, seed = 10104)
 
 # sorting can be suppressed
-bed_random(genome, sort_by = NULL, seed = 10104)
+bed_random(genome, sorted = FALSE, seed = 10104)
 
 # 500 random intervals of length 500
 bed_random(genome, length = 500, n = 500, seed = 10104)

--- a/tests/testthat/test_random.r
+++ b/tests/testthat/test_random.r
@@ -34,7 +34,7 @@ test_that("chrom sizes less than length throws an error", {
 
 test_that("intervals are sorted by default", {
   x <- bed_random(genome, n = 1e4, seed = seed)
-  y <- bed_random(genome, n = 1e4, sort_by = NULL, seed = seed)
+  y <- bed_random(genome, n = 1e4, sorted = FALSE, seed = seed)
   expect_false(all(x == y))
 
   # default sort

--- a/vignettes/benchmarks.Rmd
+++ b/vignettes/benchmarks.Rmd
@@ -116,7 +116,7 @@ x <- bed_random(genome, n = n, seed = seed_x)
 seed_y <- 9283019
 y <- bed_random(genome, n = n, seed = seed_y)
 seed_z <- 1234567
-z <- bed_random(genome, n = n, seed = seed_z, sort_by = NULL)
+z <- bed_random(genome, n = n, seed = seed_z, sorted = FALSE)
 
 # convert valr tibbles into GR objects
 x_gr <- GRanges(


### PR DESCRIPTION
Switching to base R sorting provides a performance gain over `arrange()` and future proofs the code against a regression in dev dplyr that results in a ~30x slow down. This PR also replaces the  sorting code in `bed_random()` with`bed_sort()` to avoid redundancy

Current master performance (CRAN dplyr)
``` r
library(valr)
library(microbenchmark)
n <- 1e6
seed_x <- 1010486
genome <- read_genome(valr_example('hg19.chrom.sizes.gz'))

x <- bed_random(genome, n = n, seed = seed_x)

microbenchmark(bed_sort(x),
               bed_random(genome, n = n, seed = seed_x),
               times = 2,
               unit = 's')
#> Unit: seconds
#>                                      expr        min         lq       mean
#>                               bed_sort(x) 0.03779551 0.03779551 0.03914011
#>  bed_random(genome, n = n, seed = seed_x) 0.68720326 0.68720326 0.69683440
#>      median         uq        max neval cld
#>  0.03914011 0.04048472 0.04048472     2  a
#>  0.69683440 0.70646555 0.70646555     2   b
```

With these changes that use base r radix sort (ported from data.table since r 3.3.0)

``` r
#> Unit: seconds
#>                                      expr        min         lq       mean
#>                               bed_sort(x) 0.02048263 0.02048263 0.02155842
#>  bed_random(genome, n = n, seed = seed_x) 0.15447826 0.15447826 0.16032385
#>      median         uq        max neval cld
#>  0.02155842 0.02263422 0.02263422     2  a
#>  0.16032385 0.16616943 0.16616943     2   b
```



<sup>Created on 2020-03-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>