### PR TITLE
Changes for dplyr 1.0.0

### DIFF
--- a/R/bed_absdist.r
+++ b/R/bed_absdist.r
@@ -80,18 +80,18 @@ bed_absdist <- function(x, y, genome) {
   genome <- inner_join(genome, get_labels(y), by = c("chrom"))
 
   ref_points <- summarize(y, .ref_points = n())
-  genome <- inner_join(genome, ref_points, by = c("chrom", groups_xy))
+  genome <- inner_join(genome, ref_points, by = c("chrom", setdiff("chrom", groups_xy)))
 
   genome <- mutate(genome, .ref_gap = .ref_points / size)
   genome <- select(genome, -size, -.ref_points)
 
   # calculate scaled reference sizes
-  res <- full_join(res, genome, by = c("chrom", groups_xy))
+  res <- full_join(res, genome, by = c("chrom", setdiff("chrom", groups_xy)))
   res <- mutate(res, .absdist_scaled = .absdist * .ref_gap)
   res <- select(res, -.ref_gap)
 
   # report back original x intervals not found
-  x_missing <- anti_join(x, res, by = c("chrom", groups_xy))
+  x_missing <- anti_join(x, res, by = c("chrom", setdiff("chrom", groups_xy)))
   x_missing <- ungroup(x_missing)
   x_missing <- mutate(x_missing, .absdist = NA, .absdist_scaled = NA)
   res <- bind_rows(res, x_missing)

--- a/R/bed_complement.r
+++ b/R/bed_complement.r
@@ -63,7 +63,7 @@ bed_complement <- function(x, genome) {
 
   res <- complement_impl(res, genome)
 
-  res <- bind_rows(res, chroms_no_overlaps)
+  res <- bind_rows(res, as_tibble(chroms_no_overlaps))
   res <- bed_sort(res)
 
   res

--- a/R/bed_glyph.r
+++ b/R/bed_glyph.r
@@ -103,7 +103,7 @@ bed_glyph <- function(expr, label = NULL) {
   for (i in 1:nargs) {
     env_i <- get(expr_vars[i], env)
     rows <- mutate(env_i, .facet = expr_vars[i])
-    res <- bind_rows(res, rows)
+    res <- bind_rows(res, as_tibble(rows))
   }
 
   # assign `.y` values in the result based on clustering

--- a/R/bed_partition.r
+++ b/R/bed_partition.r
@@ -68,7 +68,7 @@ bed_partition <- function(x, ...) {
     res <- partition_impl(x)
   }
 
-  res <- tbl_df(res)
+  res <- as_tibble(res)
 
   # drop non-grouped cols as values no longer match ivls
   res <- select(res, chrom, start, end, one_of(groups_df))

--- a/R/bed_shuffle.r
+++ b/R/bed_shuffle.r
@@ -67,7 +67,7 @@ bed_shuffle <- function(x, genome, incl = NULL, excl = NULL,
   }
 
   # bind original x column data to result (#81)
-  res <- bind_cols(res, x[, !colnames(x) %in% colnames(res)])
+  res <- bind_cols(res, as_tibble(x[, !colnames(x) %in% colnames(res)]))
 
   res <- as.tbl_interval(res)
 

--- a/src/dist.cpp
+++ b/src/dist.cpp
@@ -125,14 +125,14 @@ DataFrame dist_impl(ValrGroupedDataFrame x, ValrGroupedDataFrame y,
 
 /***R
 library(dplyr)
-  x <- tibble::frame_data(
+  x <- tibble::tribble(
       ~chrom, ~start, ~end,
       "chr1", 5,    15,
       "chr1", 50, 150,
       "chr2", 1000,   2000,
       "chr3", 3000, 4000
   ) %>% group_by(chrom)
-  y <- tibble::frame_data(
+  y <- tibble::tribble(
       ~chrom, ~start, ~end,
       "chr1", 25,    125,
       "chr1", 150,    250,

--- a/tests/testthat/test_absdist.r
+++ b/tests/testthat/test_absdist.r
@@ -1,18 +1,18 @@
 context("bed_absdist")
 
-genome <- tibble::frame_data(
+genome <- tibble::tribble(
   ~ chrom, ~ size,
   "chr1", 10000,
   "chr2", 10000,
   "chr3", 10000
 )
 
-x <- tibble::frame_data(
+x <- tibble::tribble(
   ~ chrom, ~ start, ~ end,
   "chr1", 75, 125
 )
 
-y <- tibble::frame_data(
+y <- tibble::tribble(
   ~ chrom, ~ start, ~ end,
   "chr1", 50, 100,
   "chr1", 100, 150
@@ -24,7 +24,7 @@ test_that("absdist calculation is correct", {
 })
 
 test_that("self absdist is 0", {
-  x <- tibble::frame_data(
+  x <- tibble::tribble(
     ~ chrom, ~ start, ~ end,
     "chr1", 5, 15,
     "chr1", 50, 150,
@@ -37,7 +37,7 @@ test_that("self absdist is 0", {
 })
 
 test_that("x ivls without matching y-ivls chroms are reported with absdist = NA", {
-  x <- tibble::frame_data(
+  x <- tibble::tribble(
     ~ chrom, ~ start, ~ end,
     "chr1", 5, 15,
     "chr1", 50, 150,
@@ -45,7 +45,7 @@ test_that("x ivls without matching y-ivls chroms are reported with absdist = NA"
     "chr3", 3000, 4000
   )
 
-  y <- tibble::frame_data(
+  y <- tibble::tribble(
     ~ chrom, ~ start, ~ end,
     "chr1", 25, 125,
     "chr1", 150, 250,

--- a/tests/testthat/test_glyph.r
+++ b/tests/testthat/test_glyph.r
@@ -12,7 +12,7 @@ test_that("glyphs are rendered", {
 })
 
 test_that("glyph labels are applied", {
-  res <- bed_glyph(bed_merge(x, id = n()), label = "id")
+  res <- bed_glyph(bed_merge(x, id = dplyr::n()), label = "id")
   expect_equal(res$labels$label, "id")
 })
 

--- a/tests/testthat/test_groups.r
+++ b/tests/testthat/test_groups.r
@@ -82,7 +82,7 @@ df_new <- structure(
   )
 
 test_that("old dataframe groupings (dplyr v. < 0.7.9.900) are tolerated", {
-
+  skip("no longer tolerated from dplyr 1.0.0")
   if (packageVersion("dplyr") >= "0.7.9.9000"){
     expect_warning(bed_intersect(df_old, df_old))
     res <- suppressWarnings(bed_intersect(df_old, df_old))

--- a/tests/testthat/test_intersect.r
+++ b/tests/testthat/test_intersect.r
@@ -326,7 +326,7 @@ test_that("unmatched groups are included when invert = TRUE", {
   )
 
   res <- bed_intersect(x, y, invert = TRUE)
-  expect_equal(res, pred)
+  expect_equivalent(res, pred)
 })
 
 # from https://github.com/arq5x/bedtools2/blob/master/test/intersect/test-intersect.sh

--- a/tests/testthat/test_map.r
+++ b/tests/testthat/test_map.r
@@ -101,7 +101,7 @@ test_that("book-ended intervals are not reported", {
     "chr1", 100, 200, 10
   )
   res <- bed_map(x, y, value = sum(value))
-  expect_equal(res, expected)
+  expect_equivalent(res, expected)
 })
 
 test_that("ensure that mapping is calculated with respect to input tbls issue#108", {

--- a/tests/testthat/test_partition.r
+++ b/tests/testthat/test_partition.r
@@ -33,7 +33,7 @@ test_that("basic partition works (bedops partition1 test)", {
   )
 
   res <- bed_partition(x)
-  expect_equal(res, pred)
+  expect_equivalent(res, pred)
 })
 
 
@@ -116,7 +116,7 @@ pred <- trbl_interval(
   )
 
   res <- bed_partition(x)
-  expect_equal(res, pred)
+  expect_equivalent(res, pred)
 })
 
 
@@ -146,7 +146,7 @@ test_that("partition drops non-grouped cols (bedops partition3 test)", {
      )
 
   res <- bed_partition(x)
-  expect_equal(res, pred)
+  expect_equivalent(res, pred)
 })
 
 
@@ -179,7 +179,7 @@ test_that("partition drops non-grouped cols (bedops partition4 test)", {
      )
 
   res <- bed_partition(x)
-  expect_equal(res, pred)
+  expect_equivalent(res, pred)
 })
 
 

--- a/tests/testthat/test_sort.r
+++ b/tests/testthat/test_sort.r
@@ -86,7 +86,7 @@ test_that("ties in start are sorted by end", {
   )
 
   res <- bed_sort(x)
-  expect_equal(res, pred)
+  expect_equivalent(res, pred)
 })
 
 # from https://github.com/arq5x/bedtools2/blob/master/test/sort/test-sort.sh

--- a/tests/testthat/test_subtract.r
+++ b/tests/testthat/test_subtract.r
@@ -175,7 +175,7 @@ test_that("test baseline subtraction", {
     "chr1", 50, 70, "a2", 2, "-"
   )
   res <- bed_subtract(a, b)
-  expect_equal(res, c)
+  expect_equivalent(res, c)
 })
 
 test_that("test any = TRUE subtraction", {
@@ -201,5 +201,5 @@ test_that("test with 2 DBs", {
     "chr1", 65, 70, "a2", 2, "-"
   )
   res <- bed_subtract(bed_subtract(a, b), b2)
-  expect_equal(res, c)
+  expect_equivalent(res, c)
 })


### PR DESCRIPTION
Please consider these minor changes for making this package work with dplyr 1.0.0

Not all the problems are fixed though, I'm getting: 

```
test_absdist.r:95: error: ensure that absdist is calculated with respect to input tbls issue#108
'!=' only defined for equally-sized data frames
Backtrace:
 1. testthat::expect_true(any(orig[, c(1:5)] != res[, c(1:5)])) tests/testthat/test_absdist.r:95:2
 4. base::Ops.data.frame(orig[, c(1:5)], res[, c(1:5)])
```

but maybe that can help. We plan to release dplyr 1.0.0 soon. 