### PR TITLE
RMySQL -> RMariaDB

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,6 @@ Suggests:
     microbenchmark,
     covr,
     curl,
-    RMySQL,
     purrr,
     tidyr,
     devtools,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,8 @@ Suggests:
     GenomicRanges,
     IRanges,
     S4Vectors,
+    DBI,
+    RMariaDB
 VignetteBuilder: knitr
 RoxygenNote: 7.1.0
 URL: http://github.com/rnabioco/valr, http://rnabioco.github.io/valr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # valr (development version)
 
+## Minor changes
+
+* `RMariaDB` has replaced the deprecated `RMySQL` package as the database backend. 
+
 # valr 0.6.1
 
 ## Bug Fixes

--- a/R/db.r
+++ b/R/db.r
@@ -27,12 +27,20 @@ NULL
 #'   tbl(ucsc, "chromInfo")
 #' }
 #' }
-#' @importFrom DBI dbConnect
-#' @importFrom RMariaDB MariaDB
 #' @export
 db_ucsc <- function(dbname, host = "genome-mysql.cse.ucsc.edu",
                     user = "genomep", password = "password",
                     port = 3306, ...) {
+  db_pkgs <- c("dbplyr", "DBI", "RMariaDB")
+  pkgs_found <- sapply(db_pkgs, requireNamespace, quietly = TRUE)
+  if (!all(pkgs_found)) {
+    missing_pkg <- db_pkgs[!pkgs_found]
+
+    stop("package(s): ", paste(missing_pkg, collapse = " "),
+         " needed for this function, please install.",
+         call. = FALSE)
+  }
+
   DBI::dbConnect(RMariaDB::MariaDB(),
                  dbname = dbname,
                  user = user,
@@ -58,10 +66,20 @@ db_ucsc <- function(dbname, host = "genome-mysql.cse.ucsc.edu",
 db_ensembl <- function(dbname, host = "ensembldb.ensembl.org",
                        user = "anonymous", password = "",
                        port = 3306, ...) {
+  db_pkgs <- c("dbplyr", "DBI", "RMariaDB")
+  pkgs_found <- sapply(db_pkgs, requireNamespace, quietly = TRUE)
+  if (!all(pkgs_found)) {
+    missing_pkg <- db_pkgs[!pkgs_found]
+
+    stop("package(s): ", paste(missing_pkg, collapse = " "),
+         " needed for this function, please install.",
+         call. = FALSE)
+  }
+
   DBI::dbConnect(RMariaDB::MariaDB(),
                  dbname = dbname,
                  user = user,
                  password = password,
                  host = host,
-                 post = port, ...) # nocov # nocov
+                 post = port, ...) # nocov
 }

--- a/R/db.r
+++ b/R/db.r
@@ -17,7 +17,7 @@ NULL
 #'
 #' @examples
 #' \dontrun{
-#' if(require(RMySQL)) {
+#' if(require(RMariaDB)) {
 #'   ucsc <- db_ucsc('hg38')
 #'
 #'   # fetch the `refGene` tbl
@@ -27,12 +27,18 @@ NULL
 #'   tbl(ucsc, "chromInfo")
 #' }
 #' }
-#'
+#' @importFrom DBI dbConnect
+#' @importFrom RMariaDB MariaDB
 #' @export
 db_ucsc <- function(dbname, host = "genome-mysql.cse.ucsc.edu",
                     user = "genomep", password = "password",
                     port = 3306, ...) {
-  src_mysql(dbname, host, port, user, password, ...) # nocov
+  DBI::dbConnect(RMariaDB::MariaDB(),
+                 dbname = dbname,
+                 user = user,
+                 password = password,
+                 host = host,
+                 post = port, ...) # nocov
 }
 
 #' @rdname db
@@ -40,7 +46,7 @@ db_ucsc <- function(dbname, host = "genome-mysql.cse.ucsc.edu",
 #'
 #' @examples
 #' \dontrun{
-#' if(require(RMySQL)) {
+#' if(require(RMariaDB)) {
 #'   # squirrel genome
 #'   ensembl <- db_ensembl('spermophilus_tridecemlineatus_core_67_2')
 #'
@@ -52,5 +58,10 @@ db_ucsc <- function(dbname, host = "genome-mysql.cse.ucsc.edu",
 db_ensembl <- function(dbname, host = "ensembldb.ensembl.org",
                        user = "anonymous", password = "",
                        port = 3306, ...) {
-  src_mysql(dbname, host, port, user, password, ...) # nocov
+  DBI::dbConnect(RMariaDB::MariaDB(),
+                 dbname = dbname,
+                 user = user,
+                 password = password,
+                 host = host,
+                 post = port, ...) # nocov # nocov
 }

--- a/man/db.Rd
+++ b/man/db.Rd
@@ -42,7 +42,7 @@ Currently \code{db_ucsc} and \code{db_ensembl} are available for connections.
 }
 \examples{
 \dontrun{
-if(require(RMySQL)) {
+if(require(RMariaDB)) {
   ucsc <- db_ucsc('hg38')
 
   # fetch the `refGene` tbl
@@ -52,9 +52,8 @@ if(require(RMySQL)) {
   tbl(ucsc, "chromInfo")
 }
 }
-
 \dontrun{
-if(require(RMySQL)) {
+if(require(RMariaDB)) {
   # squirrel genome
   ensembl <- db_ensembl('spermophilus_tridecemlineatus_core_67_2')
 


### PR DESCRIPTION
uses `DBI` to manage the connection through `RMariaDB`.  No changes on the user end. 

``` r
library(valr)
library(dplyr, warn.conflicts = FALSE)
db <- db_ensembl("spermophilus_tridecemlineatus_core_67_2")
gene <- tbl(db, "gene")
gene
#> # Source:   table<gene> [?? x 18]
#> # Database: mysql
#> #   [anonymous@ensembldb.ensembl.org:NA/spermophilus_tridecemlineatus_core_67_2]
#>    gene_id biotype analysis_id seq_region_id seq_region_start seq_region_end
#>      <int> <chr>         <int>         <int>            <int>          <int>
#>  1       1 protei…         576        163688            66803          81360
#>  2       2 protei…         576        158278            43815          91731
#>  3       3 pseudo…         576        160392             7880           8475
#>  4       4 protei…         576        154808           113557         117393
#>  5       5 protei…         576        154808           119799         136943
#>  6       6 protei…         576        154808           138506         142668
#>  7       7 protei…         576        154808           143628         157988
#>  8       8 protei…         576        154808           177334         192207
#>  9       9 protei…         576        154808           197737         208415
#> 10      10 protei…         576        165832            59373          88447
#> # … with more rows, and 12 more variables: seq_region_strand <int>,
#> #   display_xref_id <int>, source <chr>, status <chr>, description <chr>,
#> #   is_current <int>, canonical_transcript_id <int>,
#> #   canonical_annotation <chr>, stable_id <chr>, version <int>,
#> #   created_date <dttm>, modified_date <dttm>

db <- db_ucsc("hg38")
refgene <- tbl(db, "refGene")
refgene
#> # Source:   table<refGene> [?? x 16]
#> # Database: mysql [genomep@genome-mysql.cse.ucsc.edu:NA/hg38]
#>      bin name  chrom strand txStart txEnd cdsStart cdsEnd exonCount exonStarts
#>    <int> <chr> <chr> <chr>    <int> <int>    <int>  <int>     <int> <list>    
#>  1   585 NR_0… chr1  +        11873 14409    14409  14409         3 <raw [18]>
#>  2   585 NR_0… chr1  -        14361 29370    29370  29370        11 <raw [66]>
#>  3   585 NR_1… chr1  -        17368 17436    17436  17436         1 <raw [6]> 
#>  4   585 NR_1… chr1  -        17368 17436    17436  17436         1 <raw [6]> 
#>  5   585 NR_1… chr1  -        17368 17436    17436  17436         1 <raw [6]> 
#>  6   585 NR_1… chr1  -        17368 17436    17436  17436         1 <raw [6]> 
#>  7   585 NR_0… chr1  +        30365 30503    30503  30503         1 <raw [6]> 
#>  8   585 NR_0… chr1  +        30365 30503    30503  30503         1 <raw [6]> 
#>  9   585 NR_0… chr1  +        30365 30503    30503  30503         1 <raw [6]> 
#> 10   585 NR_0… chr1  +        30365 30503    30503  30503         1 <raw [6]> 
#> # … with more rows, and 6 more variables: exonEnds <list>, score <int>,
#> #   name2 <chr>, cdsStartStat <chr>, cdsEndStat <chr>, exonFrames <list>
```

<sup>Created on 2020-07-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

closes #287 