### PR TITLE
Updates for readr 2.0.0

### DIFF
--- a/inst/extdata/bug254_e.bed
+++ b/inst/extdata/bug254_e.bed
@@ -1,4 +1,3 @@
 #chr	start	stop	name	score	strand
 chr1	10000	20000	gene1	50	-	foo
 chr1	20100	25000	gene1	50	+	bar
-

--- a/tests/testthat/test_merge.r
+++ b/tests/testthat/test_merge.r
@@ -163,7 +163,9 @@ test_that("Test that precision default is high enough for formatting not to give
 })
 
 test_that("Test stranded merge with bedPlus files that have strand", {
-  expect_warning(x <- read_bed(valr_example("bug254_e.bed"), n_fields = 7, skip = 1))
+  skip_if(packageVersion("readr") <= "1.4.0")
+
+  expect_warning(x <- read_bed(valr_example("bug254_e.bed"), n_fields = 7, skip = 1, lazy = FALSE))
   x <- x %>% group_by(strand)
   res <- bed_merge(x, 200) %>% arrange(end)
   expect_equal(res$end, c(20000, 25000))


### PR DESCRIPTION
in readr 2.0.0 newlines at the end of a file will generate a row of NA
data, rather than being silently ignored. So we needed to modify the
test data to avoid a test failure due to this.

Additionally because readr 2.0.0 uses lazy parsing by default the
warning would not be triggered during the initial read, but instead
later when the malformed value is read. Setting `lazy = FALSE` instead
reads the file eagerly and preserves the expected behavior.

This test needs to be skipped for prior versions of readr,
which don't have the `lazy` parameter.

We plan to submit readr 2.0.0 to CRAN in 3-5 weeks, so you will need to send a release with this change to avoid tests failing on CRAN.