### PR TITLE
Corrected `stop()` message in `bed_random`

### DIFF
--- a/R/bed_random.r
+++ b/R/bed_random.r
@@ -36,7 +36,7 @@ bed_random <- function(genome, length = 1000, n = 1e6, seed = 0, sorted = TRUE) 
   genome <- check_genome(genome)
 
   if (!all(genome$size > length)) {
-    stop("`length` must be greater than all chrom sizes", call. = FALSE)
+    stop("`length` must be smaller than all chrom sizes", call. = FALSE)
   }
 
   out <- random_impl(genome, length, n, seed)


### PR DESCRIPTION
Corrected user feedback for stop() in bed_random. Now it correctly indicates that the issue is "length" being larger than some chrom.sizes.

Should close #385 