### PR TITLE
remove SystemRequirements from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,6 @@ VignetteBuilder:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-SystemRequirements: C++11
 Config/Needs/website:
     pkgdown,
     rnabioco/rbitemplate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # valr (development version)
 
+* Removed `SystemRequirements` from DESCRIPTION to eliminate a NOTE on CRAN.
+
 * Fixed bug in `bed_coverage()` whereby intervals from x were not reported if there was not a matching group in y. (#395).  
 
 # valr 0.6.6


### PR DESCRIPTION
Addresses new CRAN note:

https://cloud.r-project.org/web/checks/check_results_valr.html

We have a Makevars specifying CXX_STD=CXX11, which is best practice and doesn't require SystemRequirements specification:

https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Using-C_002b_002b-code