### PR TITLE
specify multiple = "all" argument added in dplyr 1.1.0

### DIFF
--- a/R/bed_absdist.r
+++ b/R/bed_absdist.r
@@ -73,7 +73,13 @@ bed_absdist <- function(x, y, genome) {
 
   # calculate reference sizes
   genome <- filter(genome, genome$chrom %in% res$chrom)
-  genome <- inner_join(genome, get_labels(y), by = c("chrom"))
+
+  if (utils::packageVersion("dplyr") > "1.0.10") {
+    genome <- inner_join(genome, get_labels(y),
+                         by = c("chrom"), multiple = "all")
+  } else {
+    genome <- inner_join(genome, get_labels(y), by = c("chrom"))
+  }
 
   ref_points <- summarize(y, .ref_points = n())
   genome <- inner_join(genome, ref_points, by = c(groups_xy))


### PR DESCRIPTION
We can safely specify multiple = "all" in `bed_absdist()` to silence this warning. There may be other conditions in other code that trigger this, but I don't see this warning in other tests, examples, or vignettes. 

Note that you need to set `Sys.setenv(TESTTHAT_PKG = "valr")` to see the warning during interactive use. 

closes #399
