### PR TITLE
Compatibility ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test_glyph.r
+++ b/tests/testthat/test_glyph.r
@@ -10,7 +10,11 @@ test_that("glyphs are rendered", {
 
 test_that("glyph labels are applied", {
   res <- bed_glyph(bed_merge(x, id = dplyr::n()), label = "id")
-  expect_equal(res$labels$label, "id")
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    expect_equal(ggplot2::get_labs(res)$label, "id")
+  } else {
+    expect_equal(res$labels$label, "id")
+  }
 })
 
 a <- tibble::tribble(


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the valr package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun