### PR TITLE
Retain sort order in `bed_slop()` and `bed_flank()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # valr (development version)
 
+* `bed_slop()` and `bed_flank()` now retain the sort order of the input intervals (#457).
+
 # valr 0.8.4
 
 * Update a test for compatibility with forthcoming ggplot2 3.6.0 (#431)

--- a/R/bed_flank.r
+++ b/R/bed_flank.r
@@ -97,7 +97,5 @@ bed_flank <- function(
     trim
   )
 
-  res <- bed_sort(res)
-
   res
 }

--- a/R/bed_slop.r
+++ b/R/bed_slop.r
@@ -132,7 +132,6 @@ bed_slop <- function(
   }
 
   res <- bound_intervals(res, genome, trim)
-  res <- bed_sort(res)
 
   res <- mutate(res, temp_start = start, temp_end = end)
 

--- a/tests/testthat/test_slop.r
+++ b/tests/testthat/test_slop.r
@@ -275,3 +275,22 @@ test_that("test edge cases", {
   expect_equal(res$start, 0)
   expect_equal(res$end, 1)
 })
+
+test_that("output remains sorted as input", {
+  genome <- tibble(
+    chrom = c("chr1", "chr2"),
+    size = c(5000, 6000)
+  )
+
+  x <- tribble(
+    ~ chrom, ~ start, ~end, ~id,
+    "chr1", 3000, 4000, 1,
+    "chr1", 3500, 4500, 2,
+    "chr1", 100, 200, 4,
+    "chr1", 150, 250, 3,
+  )
+
+  res <- bed_slop(x, both = 100, genome)
+
+  expect_equal(x$id, res$id)
+})


### PR DESCRIPTION
Fixes #434