### PR TITLE
fix: use dynamic column names for custom suffix in bed_closest

### DIFF
--- a/R/bed_closest.r
+++ b/R/bed_closest.r
@@ -119,12 +119,16 @@ bed_closest <- function(x, y, overlap = TRUE, suffix = c(".x", ".y")) {
     suffix[2]
   )
 
+  # Column names with suffixes for use in mutate
+  end_y <- paste0("end", suffix[2])
+  start_x <- paste0("start", suffix[1])
+
   res$.overlap <- 0L
   ol_ivls <- mutate(
     ol_ivls,
     .dist = case_when(
       .data[[".overlap"]] > 0 ~ 0L,
-      .data[["end.y"]] <= .data[["start.x"]] ~ -1L,
+      .data[[end_y]] <= .data[[start_x]] ~ -1L,
       TRUE ~ 1L
     )
   )

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -598,6 +598,37 @@ test_that("check reporting of adjacent intervals issue #348", {
     "chr1" ,     20 ,   21 ,
     "chr1" ,     21 ,   22
   )
+
   res <- bed_closest(x, y)
   expect_true(nrow(res) == 2)
+})
+
+test_that("custom suffix works without warnings issue #436", {
+  x <- tibble::tribble(
+    ~chrom , ~start , ~end ,
+    "chr1" ,    100 ,  125
+  )
+
+  y <- tibble::tribble(
+    ~chrom , ~start , ~end ,
+    "chr1" ,     25 ,   50 ,
+    "chr1" ,    140 ,  175
+  )
+
+  # should not produce warnings about unknown columns
+  expect_no_warning(
+    res <- bed_closest(x, y, suffix = c(".this", ".that"))
+  )
+
+  # check column names are correctly suffixed
+
+  expect_true("start.this" %in% names(res))
+  expect_true("end.this" %in% names(res))
+  expect_true("start.that" %in% names(res))
+  expect_true("end.that" %in% names(res))
+
+  # check results match default suffix behavior
+  res_default <- bed_closest(x, y)
+  expect_equal(res$.overlap, res_default$.overlap)
+  expect_equal(res$.dist, res_default$.dist)
 })


### PR DESCRIPTION
## Summary
- Fix `bed_closest()` to respect custom `suffix` parameter when computing `.dist`
- Previously hardcoded `end.y` and `start.x` caused warnings with custom suffixes
- Add test to verify custom suffixes work without warnings

Fixes #436

## Test plan
- [x] Existing `bed_closest` tests pass (54 tests)
- [x] New test verifies custom suffix works without warnings
- [x] New test verifies column names are correctly suffixed
- [x] New test verifies results match default suffix behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)