### PR TITLE
Advance deprecations: min_overlap default -> 1L; read_bed(n_fields) defunct

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # valr (development version)
 
+## Breaking changes
+
+* The `min_overlap` default changed from `0` to `1` in `bed_intersect()`, `bed_coverage()`, `bed_subtract()`, and `bed_window()`, completing the deprecation begun in 0.8.0. By default, book-ended intervals (those that touch but do not overlap) are now excluded, matching bedtools behavior. Set `min_overlap = 0L` to restore the previous behavior. Internal overlap calculations in `bed_closest()`, `bed_fisher()`, `bed_jaccard()`, `bed_projection()`, and `bed_shuffle()` continue to count book-ended intervals.
+
+* The `n_fields` argument of `read_bed()`, deprecated since 0.6.9, is now defunct and errors when supplied; fields are determined automatically from the file.
+
+## New features
+
 * `bed_map()`, `bed_intersect()`, `bed_subtract()`, `bed_coverage()`, and `bed_window()` now accept a path or URL to a bigWig (`.bw`) or bigBed (`.bb`) file in place of an interval `y`. Only the regions spanned by `x` are read from the file (the windowed regions, for `bed_window()`); local paths and `http(s)://` URLs are both supported via cpp11bigwig, avoiding the cost of loading the entire file into memory (#444).
 
 * The `data_frame()` and `as_data_frame()` re-exports from tibble are now deprecated, matching their deprecation upstream. Use `tibble::tibble()` and `tibble::as_tibble()` instead.

--- a/R/bed_closest.r
+++ b/R/bed_closest.r
@@ -103,8 +103,8 @@ bed_closest <- function(x, y, overlap = TRUE, suffix = c(".x", ".y")) {
   x <- group_by(x, across(all_of(groups_xy)))
   y <- group_by(y, across(all_of(groups_xy)))
 
-  # TODO: revisit when min_overlap default changes to 1L
-
+  # use min_overlap = 0 so book-ended (touching) intervals register as
+  # directly overlapping (distance 0), independent of the bed_intersect default
   ol_ivls <- bed_intersect(x, y, suffix = suffix, min_overlap = 0L)
 
   grp_indexes <- shared_group_indexes(x, y)

--- a/R/bed_coverage.r
+++ b/R/bed_coverage.r
@@ -53,22 +53,9 @@
 #' @seealso \url{https://bedtools.readthedocs.io/en/latest/content/tools/coverage.html}
 #'
 #' @export
-bed_coverage <- function(x, y, ..., min_overlap = NULL) {
+bed_coverage <- function(x, y, ..., min_overlap = 1L) {
   check_required(x)
   check_required(y)
-
-  # Handle min_overlap deprecation: default to 0 (legacy) but warn
-  if (is.null(min_overlap)) {
-    lifecycle::deprecate_warn(
-      when = "0.8.0",
-      what = "bed_coverage(min_overlap)",
-      details = c(
-        "The default will change from 0 (book-ended intervals overlap) to 1 (strict overlap) in a future version.",
-        "Set `min_overlap = 0L` to keep the legacy behavior, or `min_overlap = 1L` for bedtools-compatible behavior."
-      )
-    )
-    min_overlap <- 0L
-  }
 
   x <- check_interval(x)
 

--- a/R/bed_fisher.r
+++ b/R/bed_fisher.r
@@ -49,8 +49,8 @@ bed_fisher <- function(x, y, genome) {
   # heuristic from bedtools fisher.cpp
   mean_total <- mean_x + mean_y
 
-  # number of intersections (`n11` in fisher.cpp)
-  # TODO: revisit when min_overlap default changes to 1L
+  # number of intersections (`n11` in fisher.cpp); use min_overlap = 0 so
+  # book-ended intervals count toward the contingency table
   isect <- bed_intersect(x, y, min_overlap = 0L)
   n_i <- nrow(isect)
 

--- a/R/bed_intersect.r
+++ b/R/bed_intersect.r
@@ -106,23 +106,9 @@ bed_intersect <- function(
   ...,
   invert = FALSE,
   suffix = c(".x", ".y"),
-  min_overlap = NULL
+  min_overlap = 1L
 ) {
   check_required(x)
-
-  # Handle min_overlap deprecation: default to 0 (legacy) but warn
-
-  if (is.null(min_overlap)) {
-    lifecycle::deprecate_warn(
-      when = "0.8.0",
-      what = "bed_intersect(min_overlap)",
-      details = c(
-        "The default will change from 0 (book-ended intervals overlap) to 1 (strict overlap) in a future version.",
-        "Set `min_overlap = 0L` to keep the legacy behavior, or `min_overlap = 1L` for bedtools-compatible behavior."
-      )
-    )
-    min_overlap <- 0L
-  }
 
   if (...length() == 0) {
     cli::cli_abort("One or more tbls required in {.var ...}")

--- a/R/bed_jaccard.r
+++ b/R/bed_jaccard.r
@@ -59,7 +59,7 @@ bed_jaccard <- function(x, y) {
   x <- bed_merge(x)
   y <- bed_merge(y)
 
-  # TODO: revisit when min_overlap default changes to 1L
+  # use min_overlap = 0 so book-ended intervals contribute to the intersection
   res_intersect <- bed_intersect(x, y, min_overlap = 0L)
 
   if (!is.null(groups_shared)) {

--- a/R/bed_projection.r
+++ b/R/bed_projection.r
@@ -60,8 +60,8 @@ bed_projection <- function(x, y, genome, by_chrom = FALSE) {
   # flatten y intervals
   y <- bed_merge(y)
 
-  # count overlaps per chromosome,
-  # TODO: revisit when min_overlap default changes to 1L
+  # count overlaps per chromosome; use min_overlap = 0 so book-ended
+  # intervals count as overlaps
   obs_counts <- bed_intersect(x, y, min_overlap = 0L)
 
   # count overlaps

--- a/R/bed_shuffle.r
+++ b/R/bed_shuffle.r
@@ -63,7 +63,8 @@ bed_shuffle <- function(
   # defined is not evaluated explicitly, so is the default
   if (is.null(incl) && is.null(excl)) {
     incl <- genome_incl
-    # TODO: revisit when min_overlap default changes to 1L
+    # use min_overlap = 0 when building the included regions so book-ended
+    # excluded intervals are also removed
   } else if (is.null(incl) && !is.null(excl)) {
     incl <- bed_subtract(genome_incl, excl, min_overlap = 0L)
   } else if (!is.null(incl) && !is.null(excl)) {

--- a/R/bed_subtract.r
+++ b/R/bed_subtract.r
@@ -54,22 +54,9 @@
 #' bed_subtract(x, y, any = TRUE)
 #'
 #' @export
-bed_subtract <- function(x, y, any = FALSE, min_overlap = NULL) {
+bed_subtract <- function(x, y, any = FALSE, min_overlap = 1L) {
   check_required(x)
   check_required(y)
-
-  # Handle min_overlap deprecation: default to 0 (legacy) but warn
-  if (is.null(min_overlap)) {
-    lifecycle::deprecate_warn(
-      when = "0.8.0",
-      what = "bed_subtract(min_overlap)",
-      details = c(
-        "The default will change from 0 (book-ended intervals overlap) to 1 (strict overlap) in a future version.",
-        "Set `min_overlap = 0L` to keep the legacy behavior, or `min_overlap = 1L` for bedtools-compatible behavior."
-      )
-    )
-    min_overlap <- 0L
-  }
 
   x <- check_interval(x)
 

--- a/R/bed_window.r
+++ b/R/bed_window.r
@@ -115,11 +115,7 @@ bed_window <- function(x, y, genome, ...) {
     y <- read_bigwig_regions(slop_x, y)
   }
 
-  # pass new list of args to bed_intersect
-  # TODO: revisit when min_overlap default changes to 1L
-  if (!"min_overlap" %in% names(intersect_args)) {
-    intersect_args$min_overlap <- 0L
-  }
+  # pass new list of args to bed_intersect (inherits its min_overlap default)
   res <- do.call(
     bed_intersect,
     c(list("x" = slop_x, "y" = y), intersect_args)

--- a/R/read_bed.r
+++ b/R/read_bed.r
@@ -22,7 +22,7 @@ sniff_fields <- function(filename) {
 #' @param col_types column type spec for [readr::read_tsv()]
 #' @param sort sort the tbl by chrom and start
 #' @param ... options to pass to [readr::read_tsv()]
-#' @param n_fields `r lifecycle::badge("deprecated")`
+#' @param n_fields `r lifecycle::badge("defunct")`
 #'
 #' @return [ivl_df]
 #'
@@ -48,8 +48,8 @@ read_bed <- function(
   check_required(filename)
 
   if (!is.null(n_fields)) {
-    lifecycle::deprecate_warn(
-      "0.6.9",
+    lifecycle::deprecate_stop(
+      "0.10.0",
       "read_bed(n_fields)",
       details = "fields are now determined automatically from the file"
     )

--- a/man-roxygen/min_overlap.R
+++ b/man-roxygen/min_overlap.R
@@ -1,4 +1,4 @@
 #' @param min_overlap minimum overlap in base pairs required for the operation.
-#'   Set to `1` to exclude book-ended intervals (matching bedtools behavior), or
-#'   `0` to include them (legacy valr behavior). The default will change from
-#'   `0` to `1` in a future version.
+#'   Defaults to `1`, which excludes book-ended intervals (those that touch but
+#'   do not overlap), matching bedtools behavior. Set to `0` to include
+#'   book-ended intervals (the legacy valr behavior).

--- a/man/bed_coverage.Rd
+++ b/man/bed_coverage.Rd
@@ -4,7 +4,7 @@
 \alias{bed_coverage}
 \title{Compute coverage of intervals.}
 \usage{
-bed_coverage(x, y, ..., min_overlap = NULL)
+bed_coverage(x, y, ..., min_overlap = 1L)
 }
 \arguments{
 \item{x}{\link{ivl_df}}
@@ -17,9 +17,9 @@ the cost of loading the entire file.}
 \item{...}{extra arguments (not used)}
 
 \item{min_overlap}{minimum overlap in base pairs required for the operation.
-Set to \code{1} to exclude book-ended intervals (matching bedtools behavior), or
-\code{0} to include them (legacy valr behavior). The default will change from
-\code{0} to \code{1} in a future version.}
+Defaults to \code{1}, which excludes book-ended intervals (those that touch but
+do not overlap), matching bedtools behavior. Set to \code{0} to include
+book-ended intervals (the legacy valr behavior).}
 }
 \value{
 \link{ivl_df} with the following additional columns:

--- a/man/bed_intersect.Rd
+++ b/man/bed_intersect.Rd
@@ -4,13 +4,7 @@
 \alias{bed_intersect}
 \title{Identify intersecting intervals.}
 \usage{
-bed_intersect(
-  x,
-  ...,
-  invert = FALSE,
-  suffix = c(".x", ".y"),
-  min_overlap = NULL
-)
+bed_intersect(x, ..., invert = FALSE, suffix = c(".x", ".y"), min_overlap = 1L)
 }
 \arguments{
 \item{x}{\link{ivl_df}}
@@ -25,9 +19,9 @@ URLs are both supported), avoiding the cost of loading the entire file.}
 \item{suffix}{colname suffixes in output}
 
 \item{min_overlap}{minimum overlap in base pairs required for the operation.
-Set to \code{1} to exclude book-ended intervals (matching bedtools behavior), or
-\code{0} to include them (legacy valr behavior). The default will change from
-\code{0} to \code{1} in a future version.}
+Defaults to \code{1}, which excludes book-ended intervals (those that touch but
+do not overlap), matching bedtools behavior. Set to \code{0} to include
+book-ended intervals (the legacy valr behavior).}
 }
 \value{
 \link{ivl_df} with original columns from \code{x} and \code{y} suffixed with \code{.x}

--- a/man/bed_subtract.Rd
+++ b/man/bed_subtract.Rd
@@ -4,7 +4,7 @@
 \alias{bed_subtract}
 \title{Subtract two sets of intervals.}
 \usage{
-bed_subtract(x, y, any = FALSE, min_overlap = NULL)
+bed_subtract(x, y, any = FALSE, min_overlap = 1L)
 }
 \arguments{
 \item{x}{\link{ivl_df}}
@@ -17,9 +17,9 @@ the cost of loading the entire file.}
 \item{any}{remove any \code{x} intervals that overlap \code{y}}
 
 \item{min_overlap}{minimum overlap in base pairs required for the operation.
-Set to \code{1} to exclude book-ended intervals (matching bedtools behavior), or
-\code{0} to include them (legacy valr behavior). The default will change from
-\code{0} to \code{1} in a future version.}
+Defaults to \code{1}, which excludes book-ended intervals (those that touch but
+do not overlap), matching bedtools behavior. Set to \code{0} to include
+book-ended intervals (the legacy valr behavior).}
 }
 \description{
 Subtract \code{y} intervals from \code{x} intervals.

--- a/man/read_bed.Rd
+++ b/man/read_bed.Rd
@@ -33,7 +33,7 @@ read_broadpeak(filename, ...)
 
 \item{...}{options to pass to \code{\link[readr:read_tsv]{readr::read_tsv()}}}
 
-\item{n_fields}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
+\item{n_fields}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#defunct}{\figure{lifecycle-defunct.svg}{options: alt='[Defunct]'}}}{\strong{[Defunct]}}}
 }
 \value{
 \link{ivl_df}

--- a/tests/testthat/test_intersect.r
+++ b/tests/testthat/test_intersect.r
@@ -463,3 +463,20 @@ test_that("min_overlap respects larger overlap thresholds", {
   res_100 <- bed_intersect(x, y, min_overlap = 100L)
   expect_equal(nrow(res_100), 0)
 })
+
+test_that("min_overlap defaults to 1 (book-ended intervals excluded)", {
+  a <- tibble::tribble(
+    ~chrom , ~start , ~end ,
+    "chr1" ,      1 ,  100
+  )
+  b <- tibble::tribble(
+    ~chrom , ~start , ~end ,
+    "chr1" ,    100 ,  200
+  )
+
+  # default is now strict (1L): book-ended intervals do not overlap
+  expect_equal(nrow(bed_intersect(a, b)), 0)
+
+  # legacy behavior is still available
+  expect_equal(nrow(bed_intersect(a, b, min_overlap = 0L)), 1)
+})

--- a/tests/testthat/test_read_bed.r
+++ b/tests/testthat/test_read_bed.r
@@ -61,3 +61,10 @@ test_that("read bigwig", {
 test_that("read gtf", {
   expect_snapshot(read_gtf(gtf_path), error = TRUE)
 })
+
+test_that("n_fields is defunct", {
+  expect_error(
+    read_bed(bed3_path, n_fields = 3),
+    class = "defunctError"
+  )
+})

--- a/tests/testthat/test_window.r
+++ b/tests/testthat/test_window.r
@@ -26,7 +26,7 @@ test_that("both arg works", {
 
 test_that("left arg works", {
   out <- bed_window(x, y, genome, left = 110)
-  expect_equal(nrow(out), 4)
+  expect_equal(nrow(out), 3)
 })
 
 test_that("right arg works", {


### PR DESCRIPTION
Completes two gradual deprecations per the [lifecycle guidance](https://lifecycle.r-lib.org/articles/communicate.html#gradual-deprecation).

## Breaking changes

### `min_overlap` default `0` → `1`
Begun in 0.8.0 with a warning; now completed. `bed_intersect()`, `bed_coverage()`, `bed_subtract()`, and `bed_window()` now default to `min_overlap = 1L`, so **book-ended intervals (touching but not overlapping) are excluded by default**, matching bedtools. Set `min_overlap = 0L` to restore the legacy behavior. The deprecation-warning paths are removed.

### `read_bed(n_fields)` is defunct
Deprecated since 0.6.9 (~5 releases); now `deprecate_stop()` — supplying `n_fields` errors. Fields are determined automatically from the file.

## Intentionally unchanged
`bed_closest()`, `bed_fisher()`, `bed_jaccard()`, `bed_projection()`, and `bed_shuffle()` keep `min_overlap = 0L` in their **internal** overlap calculations — book-ended semantics are intrinsic to those algorithms and were never announced for change. The 6 stale `# TODO: revisit when min_overlap default changes` markers are replaced with explanatory comments.

## Test fallout
Only one assertion changed: `bed_window(left = 110)` now yields 3 rows instead of 4 (a book-ended interval correctly drops under strict overlap). Added tests for the new default and the defunct `n_fields`; updated NEWS (Breaking changes section) and the `min_overlap` doc template.

`devtools::check()`: 0 errors / 0 warnings / 0 notes. 565 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)