### PR TITLE
Improve bed_glyph: robustness, generalized args, max_rows, uniform sizing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     cli,
     cpp11bigwig (>= 0.3.0),
     dplyr (>= 1.0.0),
-    ggplot2,
+    ggplot2 (>= 3.3.0),
     lifecycle,
     readr,
     rlang,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,13 @@
 
 ## New features
 
+* `bed_glyph()` gained a `max_rows` argument to control the row limit on the
+  evaluated result (default `100`), and now reports the offending row count when
+  the limit is exceeded. It also validates `label` (an absent column is an error
+  rather than a silent no-op), supports namespace-qualified calls such as
+  `bed_glyph(valr::bed_merge(x))`, and renders every interval at a uniform
+  vertical size with the figure height scaling to the number of rows.
+
 * `bed_map()`, `bed_intersect()`, `bed_subtract()`, `bed_coverage()`, and `bed_window()` now accept a path or URL to a bigWig (`.bw`) or bigBed (`.bb`) file in place of an interval `y`. Only the regions spanned by `x` are read from the file (the windowed regions, for `bed_window()`); local paths and `http(s)://` URLs are both supported via cpp11bigwig, avoiding the cost of loading the entire file into memory (#444).
 
 * The `data_frame()` and `as_data_frame()` re-exports from tibble are now deprecated, matching their deprecation upstream. Use `tibble::tibble()` and `tibble::as_tibble()` instead.

--- a/R/bed_glyph.r
+++ b/R/bed_glyph.r
@@ -147,7 +147,9 @@ bed_glyph <- function(expr, label = NULL, max_rows = 100L) {
 #' @noRd
 glyph_plot <- function(.data, title = NULL, label = NULL) {
   if (!is.null(label) && !label %in% names(.data)) {
-    cli::cli_abort("{.arg label} ({.val {label}}) is not a column in the result.")
+    cli::cli_abort(
+      "{.arg label} ({.val {label}}) is not a column in the result."
+    )
   }
 
   # Colorbrewer 3-class `Greys`

--- a/R/bed_glyph.r
+++ b/R/bed_glyph.r
@@ -5,6 +5,8 @@
 #' @param expr expression to evaluate
 #' @param label column name to use for label values. should be present in the
 #'   result of the call.
+#' @param max_rows maximum number of rows in the evaluated result that can be
+#'   plotted. Calls producing more rows than this raise an error.
 #'
 #' @return [ggplot2::ggplot()]
 #'
@@ -34,34 +36,45 @@
 #' bed_glyph(bed_cluster(x), label = ".id")
 #'
 #' @export
-bed_glyph <- function(expr, label = NULL) {
+bed_glyph <- function(expr, label = NULL, max_rows = 100L) {
   expr <- substitute(expr)
 
-  # assign `expr <- quote(bed_intersect(x, y))` at this point to debug
-  args_all <- formals(match.fun(expr[[1]]))
-
-  # get required args i.e. those without defaults
-  args_req <- names(args_all[sapply(args_all, is.name)])
-
-  # for bed_intersect replace ... with y
-  if (expr[[1]] == "bed_intersect") {
-    args_req[args_req == "..."] <- "y"
-  }
-
-  args_excl <- c("genome", "...")
-  args_req <- args_req[!args_req %in% args_excl]
-
-  nargs <- length(args_req)
-
-  # evaluate the expression in the environment context
+  # evaluate the expression in the calling environment
   env <- parent.frame()
   res <- eval(expr, envir = env)
 
   # bail if the result is too big
-  max_rows <- 100
   if (nrow(res) > max_rows) {
-    cli::cli_abort("max_rows exceeded in bed_glyph.")
+    cli::cli_abort(
+      "Result has {nrow(res)} row{?s}, exceeding {.arg max_rows} ({max_rows}).
+       Use a smaller example or raise {.arg max_rows}."
+    )
   }
+
+  # input interval tbls are the positional (unnamed) arguments of the call that
+  # are bare symbols resolving to an interval data frame in `env`, e.g. `x` and
+  # `y`. Named arguments (`min_overlap = 0L`) and non-interval positionals (a
+  # `genome` tbl, which has no start/end) are ignored. This avoids per-function
+  # special-casing and works for namespaced calls like `valr::bed_merge(x)`.
+  call_args <- as.list(expr)[-1]
+  arg_names <- names(call_args)
+  if (is.null(arg_names)) {
+    arg_names <- rep("", length(call_args))
+  }
+  positional <- call_args[arg_names == ""]
+  is_input <- vapply(
+    positional,
+    function(a) {
+      if (!is.symbol(a) || !exists(as.character(a), envir = env)) {
+        return(FALSE)
+      }
+      obj <- get(as.character(a), envir = env)
+      is.data.frame(obj) && all(c("start", "end") %in% names(obj))
+    },
+    logical(1)
+  )
+  # unique() collapses repeated args (e.g. `bed_intersect(x, x)`) to one facet
+  input_vars <- unique(vapply(positional[is_input], as.character, character(1)))
 
   # get default columns
   cols_default <- c("chrom")
@@ -100,35 +113,32 @@ bed_glyph <- function(expr, label = NULL) {
   name_result <- "result"
   res <- mutate(res, .facet = name_result)
 
-  # these are the equivalent of the `x` and `y` formals, except are the names
-  # of the args in the quoted call.
-  expr_vars <- all.vars(expr)
-
-  # this fetches the `x` and `y` rows from the environment
-  for (i in 1:nargs) {
-    env_i <- get(expr_vars[i], env)
-    rows <- mutate(env_i, .facet = expr_vars[i])
-    res <- bind_rows(res, as_tibble(rows))
+  # add the input rows, faceted by their argument name
+  for (var in input_vars) {
+    rows <- mutate(as_tibble(get(var, envir = env)), .facet = var)
+    res <- bind_rows(res, rows)
   }
 
-  # assign `.y` values in the result based on clustering
+  # assign `.y` (stacking position) from per-facet clustering. Join back by a
+  # stable row id rather than relying on two arrange() calls producing identical
+  # orders; this also preserves the result's own `.id` column (e.g. from
+  # bed_cluster) for use as a `label`.
+  res <- mutate(res, .row = row_number())
   ys <- group_by(res, .data[[".facet"]])
   ys <- bed_cluster(ys)
   ys <- group_by(ys, .data[[".facet"]], .data[[".id"]])
-  ys <- mutate(ys, .y = row_number(.data[[".id"]]))
+  ys <- mutate(ys, .y = row_number())
   ys <- ungroup(ys)
-
-  ys <- arrange(ys, .data[[".facet"]], .data[["chrom"]], .data[["start"]])
-  res <- arrange(res, .data[[".facet"]], .data[["chrom"]], .data[["start"]])
-
-  res <- mutate(res, .y = ys$.y)
+  ys <- select(ys, all_of(c(".row", ".y")))
+  res <- left_join(res, ys, by = ".row")
+  res <- select(res, -all_of(".row"))
 
   # make name_result col appear last in the facets
-  fct_names <- c(expr_vars, name_result)
+  fct_names <- c(input_vars, name_result)
   res <- mutate(res, .facet = factor(.data[[".facet"]], levels = fct_names))
 
   # plot title
-  title <- deparse(substitute(expr))
+  title <- deparse(expr)
 
   glyph_plot(res, title, label) + glyph_theme()
 }
@@ -136,6 +146,10 @@ bed_glyph <- function(expr, label = NULL) {
 #' plot for bed_glyph
 #' @noRd
 glyph_plot <- function(.data, title = NULL, label = NULL) {
+  if (!is.null(label) && !label %in% names(.data)) {
+    cli::cli_abort("{.arg label} ({.val {label}}) is not a column in the result.")
+  }
+
   # Colorbrewer 3-class `Greys`
   fill_colors <- c("#f0f0f0", "#bdbdbd", "#636363")
 
@@ -152,20 +166,23 @@ glyph_plot <- function(.data, title = NULL, label = NULL) {
       alpha = 0.75
     ) +
     facet_grid(
-      .facet ~ .,
+      rows = vars(.data[[".facet"]]),
       switch = "y",
       scales = "free_y",
       space = "free_y"
     ) +
+    # constant (not proportional) y padding so every `.y` unit maps to the same
+    # pixel height across facets: all interval glyphs render the same size and
+    # the figure height tracks the total row count.
+    scale_y_continuous(expand = expansion(add = 0.25)) +
     scale_fill_manual(values = fill_colors) +
     labs(title = title, x = NULL, y = NULL)
 
   if (!is.null(label)) {
-    label <- as.name(label)
     aes_label <- aes(
       x = (.data[["end"]] - .data[["start"]]) / 2 + .data[["start"]],
       y = .data[[".y"]] + 0.25,
-      label = !!label
+      label = .data[[label]]
     )
     glyph <- glyph + geom_label(aes_label, na.rm = TRUE)
   }

--- a/man/bed_glyph.Rd
+++ b/man/bed_glyph.Rd
@@ -4,13 +4,16 @@
 \alias{bed_glyph}
 \title{Create example glyphs for valr functions.}
 \usage{
-bed_glyph(expr, label = NULL)
+bed_glyph(expr, label = NULL, max_rows = 100L)
 }
 \arguments{
 \item{expr}{expression to evaluate}
 
 \item{label}{column name to use for label values. should be present in the
 result of the call.}
+
+\item{max_rows}{maximum number of rows in the evaluated result that can be
+plotted. Calls producing more rows than this raise an error.}
 }
 \value{
 \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}}

--- a/tests/testthat/_snaps/glyph.md
+++ b/tests/testthat/_snaps/glyph.md
@@ -1,8 +1,16 @@
-# exceeding max intervals throws an error
+# an absent label column is an error
 
     Code
-      bed_glyph(bed_intersect(x, x, min_overlap = 0L))
+      bed_glyph(bed_merge(x), label = "does_not_exist")
+    Condition
+      Error in `glyph_plot()`:
+      ! `label` ("does_not_exist") is not a column in the result.
+
+# exceeding max_rows throws an error
+
+    Code
+      bed_glyph(bed_intersect(z, z, min_overlap = 0L))
     Condition
       Error in `bed_glyph()`:
-      ! max_rows exceeded in bed_glyph.
+      ! Result has 101 rows, exceeding `max_rows` (100). Use a smaller example or raise `max_rows`.
 

--- a/tests/testthat/_snaps/glyph/intersect-glyph-is-ok.svg
+++ b/tests/testthat/_snaps/glyph/intersect-glyph-is-ok.svg
@@ -25,8 +25,8 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMjQuMTR8NzE0LjAyfDI0Ljg1fDE5Ny45Mw==)'>
-<rect x='55.50' y='32.72' width='156.79' height='157.34' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
-<rect x='525.87' y='32.72' width='156.79' height='157.34' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
+<rect x='55.50' y='68.12' width='156.79' height='86.54' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
+<rect x='525.87' y='68.12' width='156.79' height='86.54' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -36,7 +36,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMjQuMTR8NzE0LjAyfDIwMy45MXwzNzYuOTk=)'>
-<rect x='86.86' y='211.78' width='282.22' height='157.34' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #BDBDBD; fill-opacity: 0.75;' />
+<rect x='86.86' y='247.18' width='282.22' height='86.54' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #BDBDBD; fill-opacity: 0.75;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -46,7 +46,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMjQuMTR8NzE0LjAyfDM4Mi45N3w1NTYuMDQ=)'>
-<rect x='55.50' y='390.83' width='156.79' height='157.34' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #636363; fill-opacity: 0.75;' />
+<rect x='55.50' y='426.23' width='156.79' height='86.54' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #636363; fill-opacity: 0.75;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/glyph/merge-glyph-is-ok.svg
+++ b/tests/testthat/_snaps/glyph/merge-glyph-is-ok.svg
@@ -20,45 +20,45 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjQuMTR8NzE0LjAyfDI0Ljg1fDQxOC43Ng=='>
-    <rect x='24.14' y='24.85' width='689.88' height='393.91' />
+  <clipPath id='cpMjQuMTR8NzE0LjAyfDI0Ljg1fDM3NS4wMA=='>
+    <rect x='24.14' y='24.85' width='689.88' height='350.14' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjQuMTR8NzE0LjAyfDI0Ljg1fDQxOC43Ng==)'>
-<rect x='55.50' y='281.49' width='313.58' height='119.37' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
-<rect x='369.08' y='42.76' width='313.58' height='119.37' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
+<g clip-path='url(#cpMjQuMTR8NzE0LjAyfDI0Ljg1fDM3NS4wMA==)'>
+<rect x='55.50' y='243.69' width='313.58' height='87.54' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
+<rect x='369.08' y='68.62' width='313.58' height='87.54' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #F0F0F0; fill-opacity: 0.75;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjQuMTR8NzE0LjAyfDQyNC43NHw1NTYuMDQ='>
-    <rect x='24.14' y='424.74' width='689.88' height='131.30' />
+  <clipPath id='cpMjQuMTR8NzE0LjAyfDM4MC45N3w1NTYuMDQ='>
+    <rect x='24.14' y='380.97' width='689.88' height='175.07' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjQuMTR8NzE0LjAyfDQyNC43NHw1NTYuMDQ=)'>
-<rect x='55.50' y='430.71' width='627.16' height='119.37' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #BDBDBD; fill-opacity: 0.75;' />
+<g clip-path='url(#cpMjQuMTR8NzE0LjAyfDM4MC45N3w1NTYuMDQ=)'>
+<rect x='55.50' y='424.74' width='627.16' height='87.54' style='stroke-width: 1.16; stroke-linecap: butt; stroke-linejoin: miter; fill: #BDBDBD; fill-opacity: 0.75;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS45OHwyNC4xNHwyNC44NXw0MTguNzY='>
-    <rect x='5.98' y='24.85' width='18.16' height='393.91' />
+  <clipPath id='cpNS45OHwyNC4xNHwyNC44NXwzNzUuMDA='>
+    <rect x='5.98' y='24.85' width='18.16' height='350.14' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS45OHwyNC4xNHwyNC44NXw0MTguNzY=)'>
-<rect x='5.98' y='24.85' width='18.16' height='393.91' style='stroke-width: 1.16; stroke: #333333; fill: #D9D9D9;' />
-<text transform='translate(18.36,221.81) rotate(-90)' text-anchor='middle' style='font-size: 9.60px; fill: #1A1A1A; font-family: sans;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>x</text>
+<g clip-path='url(#cpNS45OHwyNC4xNHwyNC44NXwzNzUuMDA=)'>
+<rect x='5.98' y='24.85' width='18.16' height='350.14' style='stroke-width: 1.16; stroke: #333333; fill: #D9D9D9;' />
+<text transform='translate(18.36,199.92) rotate(-90)' text-anchor='middle' style='font-size: 9.60px; fill: #1A1A1A; font-family: sans;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>x</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS45OHwyNC4xNHw0MjQuNzR8NTU2LjA0'>
-    <rect x='5.98' y='424.74' width='18.16' height='131.30' />
+  <clipPath id='cpNS45OHwyNC4xNHwzODAuOTd8NTU2LjA0'>
+    <rect x='5.98' y='380.97' width='18.16' height='175.07' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS45OHwyNC4xNHw0MjQuNzR8NTU2LjA0)'>
-<rect x='5.98' y='424.74' width='18.16' height='131.30' style='stroke-width: 1.16; stroke: #333333; fill: #D9D9D9;' />
-<text transform='translate(18.36,490.39) rotate(-90)' text-anchor='middle' style='font-size: 9.60px; fill: #1A1A1A; font-family: sans;' textLength='23.48px' lengthAdjust='spacingAndGlyphs'>result</text>
+<g clip-path='url(#cpNS45OHwyNC4xNHwzODAuOTd8NTU2LjA0)'>
+<rect x='5.98' y='380.97' width='18.16' height='175.07' style='stroke-width: 1.16; stroke: #333333; fill: #D9D9D9;' />
+<text transform='translate(18.36,468.51) rotate(-90)' text-anchor='middle' style='font-size: 9.60px; fill: #1A1A1A; font-family: sans;' textLength='23.48px' lengthAdjust='spacingAndGlyphs'>result</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='55.50,559.03 55.50,556.04 ' style='stroke-width: 1.16; stroke: #333333; stroke-linecap: butt;' />

--- a/tests/testthat/test_glyph.r
+++ b/tests/testthat/test_glyph.r
@@ -5,7 +5,6 @@ x <- tibble::tribble(
 )
 
 test_that("glyphs are rendered", {
-  skip_on_ci()
   expect_doppelganger("merge glyph is ok", bed_glyph(bed_merge(x)))
 })
 
@@ -16,6 +15,38 @@ test_that("glyph labels are applied", {
   } else {
     expect_equal(res$labels$label, "id")
   }
+})
+
+test_that("an absent label column is an error", {
+  expect_snapshot(
+    bed_glyph(bed_merge(x), label = "does_not_exist"),
+    error = TRUE
+  )
+})
+
+test_that("namespace-qualified calls are supported", {
+  expect_s3_class(bed_glyph(valr::bed_merge(x)), "ggplot")
+})
+
+test_that("a genome argument is not faceted as an input", {
+  ivl <- tibble::tribble(
+    ~chrom , ~start , ~end ,
+    "chr1" ,     25 ,   50 ,
+    "chr1" ,    100 ,  125
+  )
+  other <- tibble::tribble(
+    ~chrom , ~start , ~end ,
+    "chr1" ,     60 ,   75
+  )
+  g <- tibble::tribble(
+    ~chrom , ~size ,
+    "chr1" ,   125
+  )
+  # facets should be ivl, other, result (3) -- genome excluded
+  built <- ggplot2::ggplot_build(
+    bed_glyph(bed_window(ivl, other, g, both = 15))
+  )
+  expect_length(built$layout$panel_params, 3)
 })
 
 a <- tibble::tribble(
@@ -30,22 +61,34 @@ b <- tibble::tribble(
 )
 
 test_that("expr arguments do not need to be x and/or y", {
-  skip_on_ci()
   expect_doppelganger(
     "intersect glyph is ok",
     bed_glyph(bed_intersect(a, b, min_overlap = 0L))
   )
 })
 
-genome <- tibble::tribble(
-  ~chrom , ~size ,
-  "chr1" ,   1e6
+# deterministic, non-overlapping intervals so `bed_intersect(z, z)` yields
+# exactly nrow(z) rows (each interval overlaps only its own copy)
+z <- tibble::tibble(
+  chrom = "chr1",
+  start = seq(0L, by = 10L, length.out = 101L),
+  end = seq(0L, by = 10L, length.out = 101L) + 5L
 )
 
-x <- bed_random(genome, n = 101)
-test_that("exceeding max intervals throws an error", {
+test_that("exceeding max_rows throws an error", {
   expect_snapshot(
-    bed_glyph(bed_intersect(x, x, min_overlap = 0L)),
+    bed_glyph(bed_intersect(z, z, min_overlap = 0L)),
     error = TRUE
+  )
+})
+
+test_that("max_rows is configurable", {
+  small <- head(z, 6)
+  expect_error(
+    bed_glyph(bed_intersect(small, small, min_overlap = 0L), max_rows = 3)
+  )
+  expect_s3_class(
+    bed_glyph(bed_intersect(small, small, min_overlap = 0L), max_rows = 1000),
+    "ggplot"
   )
 })


### PR DESCRIPTION
## Summary

Reworks `bed_glyph()` for robustness, generality, and better visuals. No breaking changes; one new argument (`max_rows`).

### Robustness
- **Validate `label`** — an absent column now raises an informative error instead of being silently swallowed by `na.rm = TRUE` (which contradicted the documented behavior).
- **Stable `.y` assignment** — stacking positions are joined back by a row id rather than relying on two separate `arrange()` calls producing byte-identical orders. This also preserves the result's own `.id` column, so `bed_glyph(bed_cluster(x), label = ".id")` keeps working.

### Generalized argument handling
- Removed the hardcoded `if (expr[[1]] == "bed_intersect")` special-case and the `all.vars()`/`formals()` machinery.
- Input facets are now derived directly from the call's positional symbols that resolve to **interval** data frames (have `start`/`end`). This:
  - excludes `genome` arguments (e.g. `bed_window`, `bed_shuffle`), and
  - supports namespace-qualified calls like `bed_glyph(valr::bed_merge(x))` (previously errored in `match.fun`).

### `max_rows` + errors
- New `max_rows = 100L` argument; the abort now reports the offending row count vs. the limit.

### ggplot2 / sizing
- Constant y-expansion (`expansion(add = 0.25)`) under `space = "free_y"` so every interval renders the same vertical height while the figure height tracks the row count.
- Modern `vars()` facet spec and `.data[[label]]` aesthetic.
- Pinned `ggplot2 (>= 3.3.0)` (floor for `expansion()`).

### Tests / docs
- Dropped the redundant `skip_on_ci()` (the `helper-vdiffr.r` gate already controls when visual tests run).
- Added tests for label validation, namespaced calls, configurable `max_rows`, and the genome-exclusion regression — all with deterministic inputs.
- Regenerated vdiffr SVG baselines and the `glyph.md` error snapshot; updated `NEWS.md`.

## Test plan
- `devtools::test(filter = "glyph")` — passes (visual tests pass with `VDIFFR_RUN_TESTS=true`).
- `devtools::check()` — clean (only a spurious "future file timestamps" NOTE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)